### PR TITLE
byte_offset data type change

### DIFF
--- a/soes/hal/rt-kernel-lan9252/esc_hw.c
+++ b/soes/hal/rt-kernel-lan9252/esc_hw.c
@@ -162,7 +162,7 @@ static void ESC_read_pram (uint16_t address, void *buf, uint16_t len)
 {
    uint32_t value;
    uint8_t * temp_buf = buf;
-   uint8_t byte_offset = 0;
+   uint16_t byte_offset = 0;
    uint8_t fifo_cnt, first_byte_position, temp_len, data[4];
 
    value = ESC_PRAM_CMD_ABORT;
@@ -230,7 +230,7 @@ static void ESC_write_pram (uint16_t address, void *buf, uint16_t len)
 {
    uint32_t value;
    uint8_t * temp_buf = buf;
-   uint8_t byte_offset = 0;
+   uint16_t byte_offset = 0;
    uint8_t fifo_cnt, first_byte_position, temp_len, data[3];
 
    value = ESC_PRAM_CMD_ABORT;


### PR DESCRIPTION
uint8_t byte_offset range(0~255) can not be expressed when process data length is 255 or more.

I have declared 200 UNSIGNED16 data types in Inputs and Outputs, respectively.
At this time, address is incorrectly reflected because of data type of byte_offset in ESC_write_pram() and ESC_read_pram() function.

The attached file(byte_offset.txt) is a log obtained by printing printf() from ESC_read_pram() as shown below.
```
   while(len > 0)
   {
      temp_len = (len > 4) ? 4: len;
      /* Always read 4 byte */
      read (lan9252, (temp_buf + byte_offset), sizeof(uint32_t));

      fifo_cnt--;
      len -= temp_len;
      byte_offset += temp_len;
      printf("address=0x%x temp_buf=0x%x byte_offset=%d\n", address+byte_offset, temp, byte_offset);
   }
```
[byte_offset.txt](https://github.com/OpenEtherCATsociety/SOES/files/1171748/byte_offset.txt)

On line 64, the range of byte_offset is exceeded and address is initialized.

