### PR TITLE
FoE EOF/file length detection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project (SOES)
 
 set (SOES_VERSION_MAJOR 2)
 set (SOES_VERSION_MINOR 1)
-set (SOES_VERSION_PATCH 1)
+set (SOES_VERSION_PATCH 2)
 
 # Generate version numbers
 configure_file (

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SOES is an EtherCAT slave stack written in c. Its purpose is to learn and
 to use. All users are invited to study the source to get an understanding
 how an EtherCAT slave functions.
 
-Features as of 2.1.1:
+Features as of 2.1.2:
  - Address offset based HAL for easy ESC read/write access via any
    interface
  - Mailbox with data link layer

--- a/soes/esc_foe.c
+++ b/soes/esc_foe.c
@@ -150,7 +150,7 @@ uint16_t FOE_fwrite (uint8_t *data, uint16_t length)
        foe_cfg->fbuffer[FOEvar.fbufposition++] = *(data++);
        if(FOEvar.fbufposition >= foe_cfg->buffer_size)
        {
-          failed = foe_file->write_function (foe_file, foe_cfg->fbuffer);
+          failed = foe_file->write_function (foe_file, foe_cfg->fbuffer, FOEvar.fbufposition);
           FOEvar.fbufposition = 0;
           foe_file->address_offset += foe_cfg->buffer_size;
        }
@@ -172,23 +172,14 @@ uint16_t FOE_fwrite (uint8_t *data, uint16_t length)
  */
 uint32_t FOE_fclose (void)
 {
-   uint32_t i;
    uint32_t failed = 0;
 
    DPRINT("FOE_fclose\n");
-   if (FOEvar.fbufposition)
-   {
+   
+   failed = foe_file->write_function (foe_file, foe_cfg->fbuffer, FOEvar.fbufposition);
+   foe_file->address_offset += FOEvar.fbufposition;
+   FOEvar.fbufposition = 0;
 
-      DPRINT("FOE_fclose EXTRA write\n");
-      for(i = FOEvar.fbufposition; i < foe_cfg->buffer_size; i++)
-      {
-         foe_cfg->fbuffer[FOEvar.fbufposition++] = foe_cfg->empty_write;
-      }
-      failed = foe_file->write_function (foe_file, foe_cfg->fbuffer);
-      FOEvar.fbufposition = 0;
-      foe_file->address_offset += foe_cfg->buffer_size;
-      DPRINT("FOE_fclose EXTRA write ended\n");
-   }
    return failed;
 }
 

--- a/soes/esc_foe.h
+++ b/soes/esc_foe.h
@@ -32,15 +32,13 @@ struct foe_writefile_cfg
    /** FoE password */
    uint32_t       filepass;
    /** Pointer to application foe write function */
-   uint32_t       (*write_function) (foe_writefile_cfg_t * self, uint8_t * data);
+   uint32_t       (*write_function) (foe_writefile_cfg_t * self, uint8_t * data, size_t length);
 };
 
 typedef struct foe_cfg
 {
    /** Allocate static in caller func to fit buffer_size */
    uint8_t * fbuffer;
-   /** Write this to fill-up, ex. 0xFF for "non write" */
-   uint8_t   empty_write;
    /** Buffer size before we flush to destination */
    uint32_t  buffer_size;
    /** Number of files used in firmware update */


### PR DESCRIPTION
Finding EOF/length of a binary file during FoE transfer is hard if you can't rule out a single byte to use as foe_cfg.empty_write. 

With a length argument you can add up to get the file length and when length < foe_cfg.buffer_size this was the last data packet (FOE_fclose) which can trigger handling of the received file.

* Add length argument to FoE write_function().
* FOE_fclose() always call FoE write_function().


