### PR TITLE
Only read SM Status and Activate in the dedicated functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project (SOES)
 
 set (SOES_VERSION_MAJOR 2)
 set (SOES_VERSION_MINOR 1)
-set (SOES_VERSION_PATCH 2)
+set (SOES_VERSION_PATCH 3)
 
 # Generate version numbers
 configure_file (

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SOES is an EtherCAT slave stack written in c. Its purpose is to learn and
 to use. All users are invited to study the source to get an understanding
 how an EtherCAT slave functions.
 
-Features as of 2.1.2:
+Feature list:
  - Address offset based HAL for easy ESC read/write access via any
    interface
  - Mailbox with data link layer

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -36,11 +36,13 @@
 #define ESCREG_EEDATA               0x0508
 #define ESCREG_SM0                  0x0800
 #define ESCREG_SM0STATUS            (ESCREG_SM0 + 5)
+#define ESCREG_SM0ACTIVATE          (ESCREG_SM0 + 6)
 #define ESCREG_SM0PDI               (ESCREG_SM0 + 7)
 #define ESCREG_SM1                  (ESCREG_SM0 + 0x08)
 #define ESCREG_SM2                  (ESCREG_SM0 + 0x10)
 #define ESCREG_SM3                  (ESCREG_SM0 + 0x18)
 #define ESCREG_LOCALTIME            0x0910
+#define ESCREG_LOCALTIME_OFFSET     0x0920
 #define ESCREG_SYNC_ACT             0x0981
 #define ESCREG_SYNC_ACT_ACTIVATED   0x01
 #define ESCREG_SYNC_SYNC0_EN        0x02


### PR DESCRIPTION
The follwing fix solved two failing CTT tests when porting SOES to the TI family. 
It also make the API cleaner since the function only does what is suppose to, not implicitly something else as well.

TF1100 Data Link Layer - Mailbox Read Serice Repeat 2
TF-1200 EtherCAT State Machine - #33  SafeOp-> Init, ErrFlag = 0, SmSett 0 or SmSett 1not match

CTT have been run on TI K2GICE and XMC43relase