### PR TITLE
ecat control latch input selection and ecat reset request

### DIFF
--- a/soes/hal/xmc4/esc_hw.c
+++ b/soes/hal/xmc4/esc_hw.c
@@ -26,7 +26,7 @@
 #define ECAT_MDO                    P0_12
 #define ECAT_MCLK                   P3_3
 
-#define ENABLE_ECAT_RESET_REQ       0U //bool
+#define ENABLE_ECAT_RESET_REQ       0U
 #define ECAT_PORT_CTRL_LATCHIN0     XMC_ECAT_PORT_CTRL_LATCHIN0_P14_5
 #define ECAT_PORT_CTRL_LATCHIN1     XMC_ECAT_PORT_CTRL_LATCHIN1_P14_4
 #define ECAT_PHYADDR_OFFSET         0
@@ -122,7 +122,7 @@
 #define ECAT_MDO                    P0_12
 #define ECAT_MCLK                   P3_3
 
-#define ENABLE_ECAT_RESET_REQ       0U //bool
+#define ENABLE_ECAT_RESET_REQ       0U
 #define ECAT_PORT_CTRL_LATCHIN0     XMC_ECAT_PORT_CTRL_LATCHIN0_P14_5
 #define ECAT_PORT_CTRL_LATCHIN1     XMC_ECAT_PORT_CTRL_LATCHIN1_P14_4
 #define ECAT_PHYADDR_OFFSET         0
@@ -217,7 +217,7 @@ static const XMC_ECAT_PORT_CTRL_t port_control = {
       .latch_input0 = ECAT_PORT_CTRL_LATCHIN0,
       .latch_input1 = ECAT_PORT_CTRL_LATCHIN1,
       .phyaddr_offset = ECAT_PHYADDR_OFFSET,
-      .mdio = ECAT_PORT_CTRL_MDIO       
+      .mdio = ECAT_PORT_CTRL_MDIO
    },
    .port0 = {
       .rxd0 = ECAT_PORT0_CTRL_RXD0,

--- a/soes/hal/xmc4/esc_hw.c
+++ b/soes/hal/xmc4/esc_hw.c
@@ -26,6 +26,7 @@
 #define ECAT_MDO                    P0_12
 #define ECAT_MCLK                   P3_3
 
+#define ENABLE_ECAT_RESET_REQ       0U //bool
 #define ECAT_PORT_CTRL_LATCHIN0     XMC_ECAT_PORT_CTRL_LATCHIN0_P14_5
 #define ECAT_PORT_CTRL_LATCHIN1     XMC_ECAT_PORT_CTRL_LATCHIN1_P14_4
 #define ECAT_PHYADDR_OFFSET         0
@@ -121,6 +122,7 @@
 #define ECAT_MDO                    P0_12
 #define ECAT_MCLK                   P3_3
 
+#define ENABLE_ECAT_RESET_REQ       0U //bool
 #define ECAT_PORT_CTRL_LATCHIN0     XMC_ECAT_PORT_CTRL_LATCHIN0_P14_5
 #define ECAT_PORT_CTRL_LATCHIN1     XMC_ECAT_PORT_CTRL_LATCHIN1_P14_4
 #define ECAT_PHYADDR_OFFSET         0
@@ -211,7 +213,11 @@
 
 static const XMC_ECAT_PORT_CTRL_t port_control = {
    .common = {
-      .mdio = ECAT_PORT_CTRL_MDIO
+      .enable_rstreq = ENABLE_ECAT_RESET_REQ,
+      .latch_input0 = ECAT_PORT_CTRL_LATCHIN0,
+      .latch_input1 = ECAT_PORT_CTRL_LATCHIN1,
+      .phyaddr_offset = ECAT_PHYADDR_OFFSET,
+      .mdio = ECAT_PORT_CTRL_MDIO       
    },
    .port0 = {
       .rxd0 = ECAT_PORT0_CTRL_RXD0,


### PR DESCRIPTION
Hello guys,
I just found out that the latch inputs selected with the defines in the esc_hw.c are not actually being applied to the real hardware. Also found that there is a way to remorely reset a Slave from the master side by enabling the ECATRSTEN bit in ecat port control. Let me know your thoughts for the proposed fix.