### PR TITLE
Feature/soes defaultvalues

### DIFF
--- a/soes/ecat_slv.c
+++ b/soes/ecat_slv.c
@@ -339,4 +339,7 @@ void ecat_slv_init (esc_cfg_t * config)
    ESC_stopmbx();
    ESC_stopinput();
    ESC_stopoutput();
+
+   /* Init CoE OD default values*/
+   COE_initDefaultValues ();
 }

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -978,7 +978,6 @@ void ESC_state (void)
       {
          /* get station address */
          ESC_address ();
-         COE_initDefaultValues ();
          an = ESC_startmbx (ac);
          break;
       }

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -21,7 +21,7 @@ typedef struct CC_PACKED
    uint16_t bitlength;
    uint16_t flags;
    const char *name;
-   uint64_t value;
+   uint32_t value;
    void *data;
 } _objd;
 CC_PACKED_END


### PR DESCRIPTION
Proposal on OD and defaults.

1. We keep value uint32, to support >4byte datatypes they should always have a data instance in the OD and the user should use the default hook to initialize them,
2. The init default was erroneous placed at INIT->PREOP transition, and would always overwrite modified values if the slave enters INIT. If the user wants that behavior, he can use the pre/post state hooks and enforce the init from there.

snippet

void init_default(void)
{
   Obj.datatyptest.real64_ro = 12345.67890;
   Obj.datatyptest.real64_rw = 67890.12345;
   Obj.datatyptest.int64_rw = UINT64_MAX;
   Obj.datatyptest.int64_ro = INT64_MAX;
...
static esc_cfg_t config =
{
      .set_defaults_hook = init_default,
 