### PR TITLE
Fixes for #59 and #57

### DIFF
--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -1121,9 +1121,8 @@ void COE_initDefaultValues (void)
       i = 0;
       do
       {
-         if (objd[i].data != NULL)
+         if (objd[i].data != NULL && objd[i].bitlength <= sizeof(objd[i].value))
          {
-            /* TODO: bitlength > 64 */
             COE_setValue (&objd[i], objd[i].value);
             DPRINT ("%04x:%02x = %x\n", SDOobjects[n].index, objd[i].subindex, objd[i].value);
          }

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -21,7 +21,7 @@ typedef struct CC_PACKED
    uint16_t bitlength;
    uint16_t flags;
    const char *name;
-   uint64_t value;
+   uint32_t value;
    void *data;
 } _objd;
 CC_PACKED_END

--- a/soes/esc_eoe.c
+++ b/soes/esc_eoe.c
@@ -790,8 +790,7 @@ static void EOE_receive_fragment (void)
    }
    else
    {
-      DPRINT("Size of data exceed available buffer size\n",
-            EOEvar.rxframeoffset);
+      DPRINT("Size of data exceed available buffer size\n");
       EOE_init_rx ();
       return;
    }

--- a/soes/include/sys/gcc/cc.h
+++ b/soes/include/sys/gcc/cc.h
@@ -43,7 +43,7 @@ extern "C"
 #define CC_DEPRECATED   __attribute__((deprecated))
 
 #define CC_SWAP32(x) __builtin_bswap32 (x)
-#define CC_SWAP16(x) ((uint16_t)(x) >> 8 | ((uint16_t)(x) & 0xFF) << 8)
+#define CC_SWAP16(x) __builtin_bswap16 (x)
 
 #define CC_ATOMIC_SET(var,val)   __atomic_store_n(&var,val,__ATOMIC_SEQ_CST)
 #define CC_ATOMIC_GET(var)       __atomic_load_n(&var,__ATOMIC_SEQ_CST)

--- a/soes/include/sys/gcc/cc.h
+++ b/soes/include/sys/gcc/cc.h
@@ -70,11 +70,16 @@ extern "C"
 #endif
 
 #ifdef ESC_DEBUG
+#ifdef __rtk__
 #include <rprint.h>
-#define DPRINT(...) rprintp ("soes: "__VA_ARGS__) /* TODO */
+#define DPRINT(...) rprintp ("soes: "__VA_ARGS__)
+#else
+#include <stdio.h>
+#define DPRINT(...) printf ("soes: "__VA_ARGS__)
+#endif
 #else
 #define DPRINT(...)
-#endif  /* DEBUG */
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes for #59 and #57. Also fix to use gcc __builtin_bswap16 which has existed since gcc version 4.8.