### PR TITLE
Change order of reset EtherCAT module and PHYs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project (SOES)
 
 set (SOES_VERSION_MAJOR 3)
 set (SOES_VERSION_MINOR 0)
-set (SOES_VERSION_PATCH 0)
+set (SOES_VERSION_PATCH 1)
 
 # Generate version numbers
 configure_file (

--- a/soes/hal/rt-kernel-xmc4/esc_hw.c
+++ b/soes/hal/rt-kernel-xmc4/esc_hw.c
@@ -83,6 +83,25 @@ void ESC_enable(void)
    scu_put_peripheral_in_reset (SCU_PERIPHERAL_ECAT0);
    scu_ungate_clock_to_peripheral (SCU_PERIPHERAL_ECAT0);
    scu_release_peripheral_from_reset (SCU_PERIPHERAL_ECAT0);
+
+   /* Used to perform PHY reset after ECAT module have been released as
+    * described in 16.3.2.3 final section;
+    * "In some case PHYs may be released from reset after releasing the ECAT
+    * module, the pin for nPHY_RESET can be used as an I/O and shell be
+    * switched later to the alternate output function".
+    * Works well with relax boards.
+    */
+   static const gpio_cfg_t gpio_cfg[] =
+   {
+      { ECAT0_PHY_RESET,
+        ECAT0_PHY_RESET_GPIO_AF,
+        GPIO_STRONG_SOFT,
+        GPIO_PAD_ENABLED,
+        GPIO_POWS_DISABLED,
+        GPIO_SW },
+   };
+   /* Re-configure the pin to correct alternate output function */
+   gpio_configure (gpio_cfg, NELEMENTS (gpio_cfg));
 }
 
 /* EtherCAT module clock gating and assert reset API (Disables ECAT)*/
@@ -220,8 +239,6 @@ static void sync0_isr (void * arg)
  */
 static void ecat_isr (void * arg)
 {
-   ESC_read (ESCREG_LOCALTIME, (void *) &ESCvar.Time, sizeof (ESCvar.Time));
-   ESCvar.Time = etohl (ESCvar.Time);
    CC_ATOMIC_SET(ESCvar.ALevent, etohl(ecat0->AL_EVENT_REQ));
 
    /* Handle SM2 interrupt */
@@ -281,6 +298,9 @@ static void isr_run(void * arg)
       /* Do while to handle write of eeprom, the write to flash is delayed */
       do
       {
+         /* Update time, used by emulated eeprom handler to measure idle time */
+         ESC_read (ESCREG_LOCALTIME, (void *) &ESCvar.Time, sizeof (ESCvar.Time));
+         ESCvar.Time = etohl (ESCvar.Time);
          ecat_slv_worker(ESCREG_ALEVENT_CONTROL | ESCREG_ALEVENT_SMCHANGE
                | ESCREG_ALEVENT_SM0 | ESCREG_ALEVENT_SM1 | ESCREG_ALEVENT_EEP);
 


### PR DESCRIPTION
Used to perform PHY reset after ECAT module have been released as
described in 16.3.2.3 final section;
"In some case PHYs may be released from reset after releasing the ECAT
module, the pin for nPHY_RESET can be used as an I/O and shell be
switched later to the alternate output function".
Works well with relax boards.

fix #66


