### PR TITLE
XMC4 rt-kernel ESC HW improvments

### DIFF
--- a/soes/hal/rt-kernel-xmc4/esc_hw.c
+++ b/soes/hal/rt-kernel-xmc4/esc_hw.c
@@ -239,9 +239,8 @@ static void sync0_isr (void * arg)
  */
 static void ecat_isr (void * arg)
 {
-   ESC_read (ESCREG_LOCALTIME, (void *) &ESCvar.Time, sizeof (ESCvar.Time));
-   ESCvar.Time = etohl (ESCvar.Time);
    CC_ATOMIC_SET(ESCvar.ALevent, etohl(ecat0->AL_EVENT_REQ));
+   CC_ATOMIC_SET(ESCvar.Time, etohl(ecat0->READMode_DC_SYS_TIME[0]));
 
    /* Handle SM2 interrupt */
    if(ESCvar.ALevent & ESCREG_ALEVENT_SM2)
@@ -300,6 +299,8 @@ static void isr_run(void * arg)
       /* Do while to handle write of eeprom, the write to flash is delayed */
       do
       {
+         /* Update time, used by emulated eeprom handler to measure idle time */
+         CC_ATOMIC_SET(ESCvar.Time, etohl(ecat0->READMode_DC_SYS_TIME[0]));
          ecat_slv_worker(ESCREG_ALEVENT_CONTROL | ESCREG_ALEVENT_SMCHANGE
                | ESCREG_ALEVENT_SM0 | ESCREG_ALEVENT_SM1 | ESCREG_ALEVENT_EEP);
 

--- a/soes/hal/rt-kernel-xmc4/esc_hw.c
+++ b/soes/hal/rt-kernel-xmc4/esc_hw.c
@@ -83,6 +83,25 @@ void ESC_enable(void)
    scu_put_peripheral_in_reset (SCU_PERIPHERAL_ECAT0);
    scu_ungate_clock_to_peripheral (SCU_PERIPHERAL_ECAT0);
    scu_release_peripheral_from_reset (SCU_PERIPHERAL_ECAT0);
+
+   /* Used to perform PHY reset after ECAT module have been released as
+    * described in 16.3.2.3 final section;
+    * "In some case PHYs may be released from reset after releasing the ECAT
+    * module, the pin for nPHY_RESET can be used as an I/O and shell be
+    * switched later to the alternate output function".
+    * Works well with relax boards.
+    */
+   static const gpio_cfg_t gpio_cfg[] =
+   {
+      { ECAT0_PHY_RESET,
+        ECAT0_PHY_RESET_GPIO_AF,
+        GPIO_STRONG_SOFT,
+        GPIO_PAD_ENABLED,
+        GPIO_POWS_DISABLED,
+        GPIO_SW },
+   };
+   /* Re-configure the pin to correct alternate output function */
+   gpio_configure (gpio_cfg, NELEMENTS (gpio_cfg));
 }
 
 /* EtherCAT module clock gating and assert reset API (Disables ECAT)*/


### PR DESCRIPTION
- Update ESCvar.time in rtk esc_hw workerthread loop
  - ESCvar.time is used by emulated eeprom handler to measure idle time, when enough time have elapsed the write is assumed to be completed and the EEPROM RAM buffer is flushed to FLASH.

- Let XMC4 BSPs configure and keep ECAT PHY in reset
  - Configure ECAT_PHY_RESET as a general purpose output in BSP and set/keep PHYs in reset and let the EtherCAT slave stack handle release/re-configure of PHY reset to correct
