### PR TITLE
Init CoE SDO defaults on SOES stack init

### DIFF
--- a/soes/ecat_slv.c
+++ b/soes/ecat_slv.c
@@ -367,18 +367,20 @@ void ecat_slv_init (esc_cfg_t * config)
 
 #if USE_FOE
    /* Init FoE */
-   FOE_init();
+   FOE_init ();
 #endif
 
 #if USE_EOE
    /* Init EoE */
-   EOE_init();
+   EOE_init ();
 #endif
 
    /* reset ESC to init state */
    ESC_ALstatus (ESCinit);
    ESC_ALerror (ALERR_NONE);
-   ESC_stopmbx();
-   ESC_stopinput();
-   ESC_stopoutput();
+   ESC_stopmbx ();
+   ESC_stopinput ();
+   ESC_stopoutput ();
+   /* Init Object Dictionary default values */
+   COE_initDefaultValues ();
 }

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -978,7 +978,6 @@ void ESC_state (void)
       {
          /* get station address */
          ESC_address ();
-         COE_initDefaultValues ();
          an = ESC_startmbx (ac);
          break;
       }


### PR DESCRIPTION
The init of COE SDO defaults shall not be part of the
state machine according to ETG. Move the init to
SOES stack init where it will only be run once.

Small editorial changes on function and paranthesis
to unify in that function.

ETG input 
"
When the slave starts-up and once the CoE OD is available, i.e. once PREOP state is confirmed, the default values are expected to be available.
"
"
According to the EtherCAT specification the Mailbox communication stops during state transition PreOp to Init, cf. ETG.1000.6 – AL State Machine.  This means, the default values can only set by the Slave Application itself within Init state, which in case is Application specific and not specified by EtherCAT.  As you said with CanOpen, resetting the values is a common way in communication technology and so some Masters do so, e.g. TwinCAT."
"
