### PR TITLE
Simplify foe et al.

### DIFF
--- a/soes/esc.c
+++ b/soes/esc.c
@@ -1160,6 +1160,7 @@ void ESC_config (esc_cfg_t * cfg)
    ESCvar.mbboot[0] = mbboot0;
    ESCvar.mbboot[1] = mbboot1;
 
+   ESCvar.skip_default_initialization = cfg->skip_default_initialization;
    ESCvar.set_defaults_hook = cfg->set_defaults_hook;
    ESCvar.pre_state_change_hook = cfg->pre_state_change_hook;
    ESCvar.post_state_change_hook = cfg->post_state_change_hook;

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -266,6 +266,7 @@
 #define FOE_ERR_NOTINBOOTSTRAP         0x8009
 #define FOE_ERR_NORIGHTS               0x800A
 #define FOE_ERR_PROGERROR              0x800B
+#define FOE_ERR_CHECKSUM               0x800C
 
 #define FOE_OP_RRQ                     1
 #define FOE_OP_WRQ                     2

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -308,6 +308,7 @@ typedef struct esc_cfg
    void * user_arg;
    int use_interrupt;
    int watchdog_cnt;
+   bool skip_default_initialization;
    void (*set_defaults_hook) (void);
    void (*pre_state_change_hook) (uint8_t * as, uint8_t * an);
    void (*post_state_change_hook) (uint8_t * as, uint8_t * an);
@@ -431,6 +432,7 @@ typedef struct
    int use_interrupt;
    sm_cfg_t  mb[2];
    sm_cfg_t  mbboot[2];
+   bool skip_default_initialization;
    void (*set_defaults_hook) (void);
    void (*pre_state_change_hook) (uint8_t * as, uint8_t * an);
    void (*post_state_change_hook) (uint8_t * as, uint8_t * an);

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -47,7 +47,7 @@ typedef enum { UPLOAD, DOWNLOAD } load_t;
  * @param[in] subindex   = value on sub-index of object we want to locate
  * @return local array index if we succeed, -1 if we didn't find the index.
  */
-static int16_t SDO_findsubindex (int16_t nidx, uint8_t subindex)
+int16_t SDO_findsubindex (int16_t nidx, uint8_t subindex)
 {
    const _objd *objd;
    int16_t n = 0;

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -1630,6 +1630,12 @@ void COE_initDefaultValues (void)
    int n;
    uint8_t maxsub;
 
+   /* Let application decide if initialization will be skipped */
+   if (ESCvar.skip_default_initialization)
+   {
+      return;
+   }
+
    /* Set default values from object descriptor */
    for (n = 0; SDOobjects[n].index != 0xffff; n++)
    {

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -104,6 +104,7 @@ typedef struct
 #define COMPLETE_ACCESS_FLAG    (1 << 15)
 
 void ESC_coeprocess (void);
+int16_t SDO_findsubindex (int16_t nidx, uint8_t subindex);
 uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * sm, int max_mappings);
 void SDO_abort (uint16_t index, uint8_t subindex, uint32_t abortcode);
 void COE_initDefaultValues (void);

--- a/soes/esc_foe.c
+++ b/soes/esc_foe.c
@@ -26,20 +26,16 @@
 
 /** Variable holding current filename read at FOE Open.
  */
-char foe_file_name[FOE_FN_MAX + 1];
+static char foe_file_name[FOE_FN_MAX + 1];
 
 
-/** Main FoE configuration pointer data array. Structure i allocated and filled
- * by the application defining what preferences it require.
+/** Main FoE configuration pointer data array. Structure is allocated and filled
+ * by the application defining what preferences it requires.
  */
 static foe_cfg_t * foe_cfg;
-/** Collection of files possible to receive by FoE. Structure i allocated and
- * filled by the application defining what preferences it require.
- */
-static foe_writefile_cfg_t * foe_files;
 /** Pointer to current file configuration item used by FoE.
  */
-static foe_writefile_cfg_t * foe_file;
+static foe_file_cfg_t * foe_file;
 /** Main FoE status data array. Structure gets filled with current status
  * variables during FoE usage.
  */
@@ -54,7 +50,7 @@ static _FOEvar FOEvar;
  * @return 0= if we succeed, FOE_ERR_NOTFOUND something wrong with filename or
  * password
  */
-int FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
+static int FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
 {
    uint32_t i;
 
@@ -73,10 +69,21 @@ int FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
    /* Figure out what file they're talking about. */
    for (i = 0; i < foe_cfg->n_files; i++)
    {
-      if ((0 == strncmp (foe_file_name, foe_files[i].name, num_chars)) &&
-          (pass == foe_files[i].filepass))
+      if (0 == strncmp (foe_file_name, foe_cfg->files[i].name, num_chars))
       {
-         foe_file = &foe_files[i];
+         if (pass != foe_cfg->files[i].filepass)
+         {
+            return FOE_ERR_NORIGHTS;
+         }
+
+         if (op == FOE_OP_WRQ &&
+             (foe_cfg->files[i].write_only_in_boot) &&
+             (ESCvar.ALstatus != ESCboot))
+         {
+            return FOE_ERR_NOTINBOOTSTRAP;
+         }
+
+         foe_file = &foe_cfg->files[i];
          foe_file->address_offset = 0;
          foe_file->total_size = 0;
          switch (op)
@@ -84,13 +91,13 @@ int FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
             case FOE_OP_RRQ:
             {
                FOEvar.fposition = 0;
-               FOEvar.fend = foe_files[i].max_data;
+               FOEvar.fend = foe_cfg->files[i].max_data;
                return 0;
             }
             case FOE_OP_WRQ:
             {
                FOEvar.fposition = 0;
-               FOEvar.fend = foe_files[i].max_data;
+               FOEvar.fend = foe_cfg->files[i].max_data;
                return 0;
             }
          }
@@ -111,7 +118,7 @@ int FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
 
  * @return Number of copied bytes.
  */
-uint16_t FOE_fread (uint8_t * data, uint16_t maxlength)
+static uint16_t FOE_fread (uint8_t * data, uint16_t maxlength)
 {
    uint16_t ncopied = 0;
 
@@ -137,7 +144,7 @@ uint16_t FOE_fread (uint8_t * data, uint16_t maxlength)
 
  * @return Number of copied bytes.
  */
-uint16_t FOE_fwrite (uint8_t *data, uint16_t length)
+static uint16_t FOE_fwrite (uint8_t *data, uint16_t length)
 {
     uint16_t ncopied = 0;
     uint32_t failed = 0;
@@ -170,7 +177,7 @@ uint16_t FOE_fwrite (uint8_t *data, uint16_t length)
  *
  * @return Number of copied bytes on success, 0= if failed.
  */
-uint32_t FOE_fclose (void)
+static uint32_t FOE_fclose (void)
 {
    uint32_t failed = 0;
 
@@ -200,7 +207,7 @@ void FOE_init ()
  *
  * @param[in] code   = abort code
  */
-void FOE_abort (uint32_t code)
+static void FOE_abort (uint32_t code)
 {
    _FOE *foembx;
    uint8_t mbxhandle;
@@ -235,7 +242,7 @@ void FOE_abort (uint32_t code)
  * @return Number of data bytes written or an error number. Error numbers
  * will be greater than FOE_DATA_SIZE.
  */
-int FOE_send_data_packet ()
+static int FOE_send_data_packet ()
 {
    _FOE *foembx;
    uint16_t data_len;
@@ -266,7 +273,7 @@ int FOE_send_data_packet ()
 
  * @return 0= or error number.
  */
-int FOE_send_ack ()
+static int FOE_send_ack ()
 {
    _FOE *foembx;
    uint8_t mbxhandle;
@@ -299,7 +306,7 @@ int FOE_send_ack ()
  * On error we will send FOE Abort.
  *
  */
-void FOE_read ()
+static void FOE_read ()
 {
    _FOE *foembx;
    uint32_t data_len;
@@ -340,18 +347,11 @@ void FOE_read ()
       FOE_abort (res);
    }
 }
-#else
-void FOE_read()
-{
-   FOE_abort(FOE_ERR_NOTDEFINED);
-}
-#endif
 
-#ifdef FOE_READ_SUPPORTED
 /** FoE data ack handler. Will continue sending next frame until finished.
  * On error we will send FOE Abort.
  */
-void FOE_ack ()
+static void FOE_ack ()
 {
    int res;
 
@@ -383,7 +383,7 @@ void FOE_ack ()
  * receive data. On error we will send FOE Abort.
  *
  */
-void FOE_write ()
+static void FOE_write ()
 {
    _FOE *foembx;
    uint32_t data_len;
@@ -421,11 +421,11 @@ void FOE_write ()
       FOE_abort (res);
    }
 }
-/** FoE data request handler. Validates and reads data until we're finsihed. Every
- * read frame follwed by an Ack frame. On error we will send FOE Abort.
+/** FoE data request handler. Validates and reads data until we're finished. Every
+ * read frame followed by an Ack frame. On error we will send FOE Abort.
  *
  */
-void FOE_data ()
+static void FOE_data ()
 {
    _FOE *foembx;
    uint32_t packet;
@@ -444,7 +444,7 @@ void FOE_data ()
 
    if (packet != FOEvar.foepacket)
    {
-      DPRINT("FOE_data packet error,packet: %d foeheader.packet: %d\n",packet,FOEvar.foepacket);
+      DPRINT("FOE_data packet error, packet: %d, foeheader.packet: %d\n",packet,FOEvar.foepacket);
       FOE_abort (FOE_ERR_PACKETNO);
    }
    else if (data_len == 0)
@@ -499,11 +499,11 @@ void FOE_data ()
 }
 
 #ifdef FOE_READ_SUPPORTED
-/** FoE read request buys handler. Send an Ack of last frame again. On error
+/** FoE read request busy handler. Send an Ack of last frame again. On error
  * we will send FOE Abort.
  *
  */
-void FOE_busy ()
+static void FOE_busy ()
 {
    /* Only valid if we're servicing a read request. */
    if (FOEvar.foestate != FOE_WAIT_FOR_ACK)
@@ -523,7 +523,7 @@ void FOE_busy ()
 /** FoE error requesthandler. Send an FOE Abort.
  *
  */
-void FOE_error ()
+static void FOE_error ()
 {
    /* Master panic! abort the transfer. */
    FOE_abort (0);
@@ -534,14 +534,10 @@ void FOE_error ()
  *
  * @param[in] cfg       = Pointer to by the Application static declared
  * configuration variable holding application specific details.
- * @param[in] cfg_files = Pointer to by the Application static declared
- * configuration variable holding file specific details for files to be handled
- * by FoE
  */
-void FOE_config (foe_cfg_t * cfg, foe_writefile_cfg_t * cfg_files)
+void FOE_config (foe_cfg_t * cfg)
 {
    foe_cfg = cfg;
-   foe_files = cfg_files;
 }
 
 /** Main FoE function checking the status on current mailbox buffers carrying

--- a/soes/esc_foe.c
+++ b/soes/esc_foe.c
@@ -403,7 +403,7 @@ void FOE_write ()
 
    /* Get an address we can write the file to, if possible. */
    res = FOE_fopen (foembx->filename, data_len, password, FOE_OP_WRQ);
-   DPRINT("FOE_write\n");
+   DPRINT("%s %sOK, file \"%s\"\n", __func__, (res == 0) ? "" : "N", foe_file_name);
    if (res == 0)
    {
       res = FOE_send_ack ();

--- a/soes/esc_foe.h
+++ b/soes/esc_foe.h
@@ -14,7 +14,7 @@
 #include <cc.h>
 
 /** Maximum number of characters allowed in a file name. */
-#define FOE_FN_MAX      15
+#define FOE_FN_MAX      31
 
 typedef struct foe_writefile_cfg foe_writefile_cfg_t;
 struct foe_writefile_cfg

--- a/soes/esc_foe.h
+++ b/soes/esc_foe.h
@@ -16,8 +16,8 @@
 /** Maximum number of characters allowed in a file name. */
 #define FOE_FN_MAX      31
 
-typedef struct foe_writefile_cfg foe_writefile_cfg_t;
-struct foe_writefile_cfg
+typedef struct foe_file_cfg foe_file_cfg_t;
+struct foe_file_cfg
 {
    /** Name of file to receive from master */
    const char * name;
@@ -31,8 +31,12 @@ struct foe_writefile_cfg
    uint32_t       total_size;
    /** FoE password */
    uint32_t       filepass;
+   /** This file can be written only in BOOT state. Intended for FW files */
+   uint8_t        write_only_in_boot;
+   /** for feature use */
+   uint32_t       padding:24;
    /** Pointer to application foe write function */
-   uint32_t       (*write_function) (foe_writefile_cfg_t * self, uint8_t * data, size_t length);
+   uint32_t       (*write_function) (foe_file_cfg_t * self, uint8_t * data, size_t length);
 };
 
 typedef struct foe_cfg
@@ -44,7 +48,7 @@ typedef struct foe_cfg
    /** Number of files used in firmware update */
    uint32_t  n_files;
    /** Pointer to files configured to be used by FoE */
-   foe_writefile_cfg_t * files;
+   foe_file_cfg_t * files;
 } foe_cfg_t;
 
 typedef struct CC_PACKED
@@ -66,7 +70,7 @@ typedef struct CC_PACKED
 } _FOEvar;
 
 /* Initializes FoE state. */
-void FOE_config (foe_cfg_t * cfg, foe_writefile_cfg_t * cfg_files);
+void FOE_config (foe_cfg_t * cfg);
 void FOE_init (void);
 void ESC_foeprocess (void);
 


### PR DESCRIPTION
A new configuration parameter is added: skip_default_initialization (which should be set to true if the application wants to skip the default initialization from object descriptors).