### PR TITLE
Declare rxpdo, txpdo as arrays

### DIFF
--- a/soes/ecat_slv.c
+++ b/soes/ecat_slv.c
@@ -25,13 +25,13 @@ static volatile int watchdog;
 #if MAX_MAPPINGS_SM2 > 0
 static uint8_t rxpdo[MAX_RXPDO_SIZE] __attribute__((aligned (8)));
 #else
-extern uint8_t * rxpdo;
+extern uint8_t rxpdo[];
 #endif
 
 #if MAX_MAPPINGS_SM3 > 0
 static uint8_t txpdo[MAX_TXPDO_SIZE] __attribute__((aligned (8)));
 #else
-extern uint8_t * txpdo;
+extern uint8_t txpdo[];
 #endif
 
 /** Function to pre-qualify the incoming SDO download.


### PR DESCRIPTION
Rxpdo/txpdo were declared as external pointers if MAX_MAPPINGS2/3 were
0. However they must be declared as arrays for an external unit to be
able to use them as such.

Change-Id: I4bd547ae809ccfcb2dc1761f0f511f7e6088b712


