### PR TITLE
Add support for input- or output only slaves

### DIFF
--- a/soes/ecat_slv.c
+++ b/soes/ecat_slv.c
@@ -202,7 +202,8 @@ void DIG_process (uint8_t flags)
       }
 
       if ((CC_ATOMIC_GET(watchdog) <= 0) &&
-          ((CC_ATOMIC_GET(ESCvar.App.state) & APPSTATE_OUTPUT) > 0))
+          ((CC_ATOMIC_GET(ESCvar.App.state) & APPSTATE_OUTPUT) > 0) &&
+           (ESCvar.ESC_SM2_sml > 0))
       {
          DPRINT("DIG_process watchdog expired\n");
          ESC_ALstatusgotoerror((ESCsafeop | ESCerror), ALERR_WATCHDOG);


### PR DESCRIPTION
Seperate validation of SM configuration that
depend on size of tx/rx pdo.

Add disable of SM3 when input only slave
reports error in OP.

Don't enable SM3 on start input if no inputs

Don't enable SM2 on start outputs if no
outputs

fix #113


