### PR TITLE
do not update output variables in SafeOp

### DIFF
--- a/soes/ecat_slv.c
+++ b/soes/ecat_slv.c
@@ -227,7 +227,7 @@ void DIG_process (uint8_t flags)
       }
       else if (ESCvar.ALevent & ESCREG_ALEVENT_SM2)
       {
-         RXPDO_update();
+         ESC_read (ESC_SM2_sma, rxpdo, ESCvar.ESC_SM2_sml);
       }
    }
 


### PR DESCRIPTION
Just read SM data to reset SM Watchdog but do not update the output variables linked to the RxPDOs in SafeOp

Closes #122 


