### PR TITLE
Add more fine-grained control of default values

### DIFF
--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -1726,7 +1726,7 @@ void COE_initDefaultValues (void)
       i = 0;
       do
       {
-         if (objd[i].data != NULL)
+         if ((objd[i].data != NULL) && (!(objd[i].flags & ATYPE_NODEFAULT)))
          {
             COE_setValue (&objd[i], objd[i].value);
             DPRINT ("%04x:%02x = %x\n", SDOobjects[n].index, objd[i].subindex, objd[i].value);

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -96,6 +96,7 @@ typedef struct
 #define ATYPE_Wop               0x20
 #define ATYPE_RXPDO             0x40
 #define ATYPE_TXPDO             0x80
+#define ATYPE_NODEFAULT       0x8000
 
 #define ATYPE_RO                (ATYPE_Rpre | ATYPE_Rsafe | ATYPE_Rop)
 #define ATYPE_WO                (ATYPE_Wpre | ATYPE_Wsafe | ATYPE_Wop)


### PR DESCRIPTION
Add a new flag to the object dictionary that makes `COE_initDefaultValues` skip setting default values.

Usecase:
Say that you have a object dictionary that should contain common values between all boards on a product but certain elements are have different defaults (configuration parameters, s/n, etc).

The current stack only have a "all or nothing" approach with the configuration parameter `skip_default_initialization` so that is not useful here. It is possible to use the `set_defaults_hook` and override values after they have been set to the default value. However, it felt like a better solution to just protect certain elements instead.
