### PR TITLE
Add reference to objectlist in SM mappings

### DIFF
--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -202,6 +202,15 @@ uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * mappings,
                   }
 
                   mappings[mapIx].obj = mapping;
+                  /* Save object list reference */
+                  if(mapping != NULL)
+                  {
+                     mappings[mapIx].objectlistitem = &SDOobjects[nidx];
+                  }
+                  else
+                  {
+                     mappings[mapIx].objectlistitem = NULL;
+                  }
                   mappings[mapIx++].offset = offset;
                }
 

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -41,6 +41,7 @@ CC_PACKED_END
 typedef struct
 {
    const _objd * obj;
+   const _objectlist * objectlistitem;
    uint16_t offset;
 } _SMmap;
 


### PR DESCRIPTION
Rationale, users might need more info on what
object it is that is mapped. Having a reference to objectlist enable the user to know what index it is and got a reference to the entire object. The obj
only know what subindex it is.

fixes #137


