### PR TITLE
Fix/warnings generated by flag wconversion

### DIFF
--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -17,4 +17,4 @@ include_directories(
   )
 
 # Common compile flags
-add_compile_options(-Wall -Wextra -Wno-unused-parameter -Werror)
+add_compile_options(-Wall -Wextra -Wconversion -Wno-unused-parameter -Werror)

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -62,7 +62,7 @@ void ESC_ALstatusgotoerror (uint8_t status, uint16_t errornumber)
    as = ESCvar.ALstatus & ESCREG_AL_ERRACKMASK;
    an = as;
    /* Set the state transition, new state in high bits and old in bits  */
-   as = ((status & ESCREG_AL_ERRACKMASK) << 4) | (as & 0x0f);
+   as = (uint8_t)(((status & ESCREG_AL_ERRACKMASK) << 4) | (as & 0x0f));
    /* Call post state change hook case it have been configured  */
    if (ESCvar.pre_state_change_hook != NULL)
    {
@@ -170,7 +170,7 @@ void ESC_SMenable (uint8_t n)
 {
    _ESCsm2 *sm;
    sm = (_ESCsm2 *)&ESCvar.SM[n];
-   sm->ActPDI &= ~ESCREG_SMENABLE_BIT;
+   sm->ActPDI &= (uint8_t)~ESCREG_SMENABLE_BIT;
    ESC_SMwritepdi (n);
 }
 /** Write 1 to Bit0 in SM PDI control register 0x807(+ offset to SyncManager n) to De-activte the Sync Manager n.
@@ -487,7 +487,7 @@ uint8_t ESC_claimbuffer (void)
       MBh->address = htoes (0x0000);      // destination is master
       MBh->channel = 0;
       MBh->priority = 0;
-      MBh->mbxcnt = ESCvar.mbxcnt;
+      MBh->mbxcnt = ESCvar.mbxcnt & 0xFU;
       ESCvar.txcue++;
    }
    return n;
@@ -601,7 +601,7 @@ uint8_t ESC_mbxprocess (void)
             ESC_writembx (ESCvar.mbxbackup);
          }
          ESCvar.toggle = ESCvar.SM[1].ECrep;
-         ESCvar.SM[1].PDIrep = ESCvar.toggle;
+         ESCvar.SM[1].PDIrep = ESCvar.toggle & 0x1U;
          ESC_SMwritepdi (1);
       }
       return 0;
@@ -1100,7 +1100,7 @@ void ESC_state (void)
    }
 
    /* Mask high bits ALcommand, low bits ALstatus */
-   as = (ac << 4) | (as & 0x0f);
+   as = (uint8_t)((ac << 4) | (as & 0x0f));
 
    /* Call post state change hook case it have been configured  */
    if (ESCvar.pre_state_change_hook != NULL)

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -136,7 +136,7 @@ uint32_t ESC_ALeventread (void)
 void ESC_SMack (uint8_t n)
 {
    uint8_t dummy;
-   ESC_read (ESCREG_SM0ACTIVATE + (n << 3), &dummy, 1);
+   ESC_read ((uint16_t)(ESCREG_SM0ACTIVATE + (n << 3)), &dummy, 1);
 }
 
 /** Read SM Status register 0x805(+ offset to SyncManager n) and save the
@@ -148,7 +148,7 @@ void ESC_SMstatus (uint8_t n)
 {
    _ESCsm2 *sm;
    sm = (_ESCsm2 *)&ESCvar.SM[n];
-   ESC_read (ESCREG_SM0STATUS + (n << 3), &(sm->Status), 1);
+   ESC_read ((uint16_t)(ESCREG_SM0STATUS + (n << 3)), &(sm->Status), 1);
 }
 
 /** Write ESCvar.SM[n] data to ESC PDI control register 0x807(+ offset to SyncManager n).
@@ -159,7 +159,7 @@ void ESC_SMwritepdi (uint8_t n)
 {
    _ESCsm2 *sm;
    sm = (_ESCsm2 *)&ESCvar.SM[n];
-   ESC_write (ESCREG_SM0PDI + (n << 3), &(sm->ActPDI), 1);
+   ESC_write ((uint16_t)(ESCREG_SM0PDI + (n << 3)), &(sm->ActPDI), 1);
 }
 
 /** Write 0 to Bit0 in SM PDI control register 0x807(+ offset to SyncManager n) to Activate the Sync Manager n.
@@ -414,9 +414,9 @@ void ESC_readmbx (void)
 
    if (length > (ESC_MBX0_sml - ESC_MBXHSIZE))
    {
-      length = ESC_MBX0_sml - ESC_MBXHSIZE;
+      length = (uint16_t)(ESC_MBX0_sml - ESC_MBXHSIZE);
    }
-   ESC_read (ESC_MBX0_sma + ESC_MBXHSIZE, MB->b, length);
+   ESC_read ((uint16_t)(ESC_MBX0_sma + ESC_MBXHSIZE), MB->b, length);
    if (length + ESC_MBXHSIZE < ESC_MBX0_sml)
    {
       ESC_read (ESC_MBX0_sme, &length, 1);
@@ -439,9 +439,9 @@ void ESC_writembx (uint8_t n)
 
    if (length > (ESC_MBX1_sml - ESC_MBXHSIZE))
    {
-      length = ESC_MBX1_sml - ESC_MBXHSIZE;
+      length = (uint16_t)(ESC_MBX1_sml - ESC_MBXHSIZE);
    }
-   ESC_write (ESC_MBX1_sma, MBh, ESC_MBXHSIZE + length);
+   ESC_write (ESC_MBX1_sma, MBh, (uint16_t)(ESC_MBXHSIZE + length));
    if (length + ESC_MBXHSIZE < ESC_MBX1_sml)
    {
       ESC_write (ESC_MBX1_sme, &dummy, 1);

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -210,9 +210,9 @@
 #define MBXstate_backup                 0x05
 #define MBXstate_again                  0x06
 
-#define COE_DEFAULTLENGTH               0x0a
-#define COE_HEADERSIZE                  0x0a
-#define COE_SEGMENTHEADERSIZE           0x03
+#define COE_DEFAULTLENGTH               0x0AU
+#define COE_HEADERSIZE                  0x0AU
+#define COE_SEGMENTHEADERSIZE           0x03U
 #define COE_SDOREQUEST                  0x02
 #define COE_SDORESPONSE                 0x03
 #define COE_SDOINFORMATION              0x08
@@ -467,7 +467,7 @@ typedef struct
    uint16_t (*esc_check_dc_handler) (void);
    int (*get_device_id) (uint16_t * device_id);
    uint8_t MBXrun;
-   size_t activembxsize;
+   uint32_t activembxsize;
    sm_cfg_t * activemb0;
    sm_cfg_t * activemb1;
    uint16_t ESC_SM2_sml;
@@ -701,11 +701,11 @@ typedef struct
 #define ESC_SM3_smc         (SM3_smc)
 #define ESC_SM3_act         (SM3_act)
 
-#define ESC_MBXHSIZE        sizeof(_MBXh)
+#define ESC_MBXHSIZE        ((uint32_t)sizeof(_MBXh))
 #define ESC_MBXDSIZE        (ESC_MBXSIZE - ESC_MBXHSIZE)
-#define ESC_FOEHSIZE        sizeof(_FOEh)
+#define ESC_FOEHSIZE        (uint32_t)sizeof(_FOEh)
 #define ESC_FOE_DATA_SIZE   (ESC_MBXSIZE - (ESC_MBXHSIZE +ESC_FOEHSIZE))
-#define ESC_EOEHSIZE        sizeof(_EOEh)
+#define ESC_EOEHSIZE        ((uint32_t)sizeof(_EOEh))
 #define ESC_EOE_DATA_SIZE   (ESC_MBXSIZE - (ESC_MBXHSIZE +ESC_EOEHSIZE))
 
 void ESC_config (esc_cfg_t * cfg);

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -489,8 +489,8 @@ typedef struct
    uint8_t segmented;
    void *data;
    uint16_t entries;
-   uint16_t frags;
-   uint16_t fragsleft;
+   uint32_t frags;
+   uint32_t fragsleft;
    uint16_t index;
    uint8_t subindex;
    uint16_t flags;
@@ -506,7 +506,7 @@ typedef struct
    /* Volatile since it may be read from ISR */
    volatile int watchdogcnt;
    volatile uint32_t Time;
-   volatile uint16_t ALevent;
+   volatile uint32_t ALevent;
    volatile int8_t synccounter;
    volatile _App App;
    uint8_t mbxdata[PREALLOC_BUFFER_SIZE];

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -18,7 +18,7 @@
 #include "esc.h"
 #include "esc_coe.h"
 
-#define BITS2BYTES(b) ((b + 7) >> 3)
+#define BITS2BYTES(b) ((b + 7U) >> 3)
 #define BITSPOS2BYTESOFFSET(b) (b >> 3)
 
 /* Fetch value from object dictionary */
@@ -48,7 +48,7 @@ typedef enum { UPLOAD, DOWNLOAD } load_t;
  * @param[in] subindex   = value on sub-index of object we want to locate
  * @return local array index if we succeed, -1 if we didn't find the index.
  */
-int16_t SDO_findsubindex (int16_t nidx, uint8_t subindex)
+int16_t SDO_findsubindex (int32_t nidx, uint8_t subindex)
 {
    const _objd *objd;
    int16_t n = 0;
@@ -118,9 +118,10 @@ int32_t SDO_findobject (uint16_t index)
 uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * mappings,
                     int max_mappings)
 {
-   uint16_t offset = 0, hobj;
+   uint32_t offset = 0;
+   uint16_t hobj;
    uint8_t si, sic, c;
-   int16_t nidx;
+   int32_t nidx;
    const _objd *objd;
    const _objd *objd1c1x;
    int mapIx = 0;
@@ -159,7 +160,7 @@ uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * mappings,
 
                if (max_mappings > 0)
                {
-                  uint16_t index = value >> 16;
+                  uint16_t index = (uint16_t)(value >> 16);
                   uint8_t subindex = (value >> 8) & 0xFF;
                   const _objd * mapping;
 
@@ -230,7 +231,7 @@ uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * mappings,
       *nmappings = 0;
    }
 
-   return BITS2BYTES (offset);
+   return BITS2BYTES (offset) & 0xFFFF;
 }
 
 /** Copy to mailbox.
@@ -239,7 +240,7 @@ uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * mappings,
  * @param[in] dest   = pointer to destination
  * @param[in] size   = Size to copy
  */
-static void copy2mbx (void *source, void *dest, uint16_t size)
+static void copy2mbx (void *source, void *dest, size_t size)
 {
    memcpy (dest, source, size);
 }
@@ -297,7 +298,8 @@ static void SDO_upload (void)
    _COEsdo *coesdo, *coeres;
    uint16_t index;
    uint8_t subindex;
-   int16_t nidx, nsub;
+   int32_t nidx;
+   int32_t nsub;
    uint8_t MBXout;
    uint32_t size;
    uint8_t dss;
@@ -345,14 +347,14 @@ static void SDO_upload (void)
             }
             coeres->index = htoes (index);
             coeres->subindex = subindex;
-            coeres->command = COE_COMMAND_UPLOADRESPONSE +
+            coeres->command = COE_COMMAND_UPLOADRESPONSE |
                COE_SIZE_INDICATOR;
             /* convert bits to bytes */
             size = BITS2BYTES(size);
             if (size <= 4)
             {
                /* expedited response i.e. length<=4 bytes */
-               coeres->command += COE_EXPEDITED_INDICATOR + dss;
+               coeres->command |= (COE_EXPEDITED_INDICATOR | dss);
                void *dataptr = ((objd + nsub)->data) ?
                      (objd + nsub)->data : (void *)&((objd + nsub)->value);
                abort = ESC_upload_pre_objecthandler (index, subindex,
@@ -440,7 +442,7 @@ static void SDO_upload (void)
 }
 
 static uint32_t complete_access_get_variables(_COEsdo *coesdo, uint16_t *index,
-                                              uint8_t *subindex, int16_t *nidx,
+                                              uint8_t *subindex, int32_t *nidx,
                                               int16_t *nsub)
 {
    *index = etohs (coesdo->index);
@@ -468,11 +470,11 @@ static uint32_t complete_access_get_variables(_COEsdo *coesdo, uint16_t *index,
 }
 
 static uint32_t complete_access_subindex_loop(const _objd *objd,
-                                              int16_t nidx,
+                                              int32_t nidx,
                                               int16_t nsub,
                                               uint8_t *mbxdata,
                                               load_t load_type,
-                                              uint16_t max_bytes)
+                                              uint32_t max_bytes)
 {
    /* Objects with dynamic entries cannot be accessed with Complete Access */
    if ((objd->datatype == DTYPE_VISIBLE_STRING) ||
@@ -504,7 +506,7 @@ static uint32_t complete_access_subindex_loop(const _objd *objd,
          if (bitoffset != 0)
          {
             /* move on to next byte boundary */
-            size += (8 - bitoffset);
+            size += (8U - bitoffset);
          }
          if (mbxdata != NULL)
          {
@@ -533,19 +535,21 @@ static uint32_t complete_access_subindex_loop(const _objd *objd,
       else if ((load_type == UPLOAD) && (mbxdata != NULL))
       {
          /* copy a bit data type into correct position */
-         uint8_t bitmask = (1 << bitlen) - 1;
+         uint32_t bitmask = (1U << bitlen) - 1U;
+         uint32_t tempmask;
          if (READ_ACCESS(access, state))
          {
             if (bitoffset == 0)
             {
                mbxdata[BITSPOS2BYTESOFFSET(size)] = 0;
             }
-            mbxdata[BITSPOS2BYTESOFFSET(size)] |=
-                  (*(uint8_t *)ul_source & bitmask) << bitoffset;
+            tempmask = (*(uint8_t *)ul_source & bitmask) << bitoffset;
+            mbxdata[BITSPOS2BYTESOFFSET(size)] |= (uint8_t)tempmask;
          }
          else
          {
-            mbxdata[BITSPOS2BYTESOFFSET(size)] &= ~(bitmask << bitoffset);
+            tempmask = ~(bitmask << bitoffset);
+            mbxdata[BITSPOS2BYTESOFFSET(size)] &= (uint8_t)tempmask;
          }
       }
 
@@ -586,7 +590,8 @@ static void SDO_upload_complete_access (void)
    _COEsdo *coesdo = (_COEsdo *) &MBX[0];
    uint16_t index;
    uint8_t subindex;
-   int16_t nidx, nsub;
+   int32_t nidx;
+   int16_t nsub;
    uint32_t abortcode = complete_access_get_variables
                            (coesdo, &index, &subindex, &nidx, &nsub);
    if (abortcode != 0)
@@ -611,7 +616,7 @@ static void SDO_upload_complete_access (void)
    uint32_t size = complete_access_subindex_loop(objd, nidx, nsub, NULL, UPLOAD, 0);
 
    /* expedited bits used calculation */
-   uint8_t dss = (size > 24) ? 0 : (4 * (3 - ((size - 1) >> 3)));
+   uint8_t dss = (size > 24) ? 0 : (uint8_t)(4U * (3U - ((size - 1U) >> 3)));
 
    /* convert bits to bytes */
    size = BITS2BYTES(size);
@@ -709,7 +714,7 @@ static void SDO_uploadsegment (void)
       coeres = (_COEsdo *) &MBX[MBXout * ESC_MBXSIZE];
       offset = ESCvar.fragsleft;
       size = ESCvar.frags - ESCvar.fragsleft;
-      uint8_t command = COE_COMMAND_UPLOADSEGMENT +
+      uint8_t command = COE_COMMAND_UPLOADSEGMENT |
             (coesdo->command & COE_TOGGLEBIT);  /* copy toggle bit */
       init_coesdo(coeres, COE_SDORESPONSE, command,
             coesdo->index, coesdo->subindex);
@@ -728,14 +733,14 @@ static void SDO_uploadsegment (void)
          ESCvar.segmented = 0;
          ESCvar.frags = 0;
          ESCvar.fragsleft = 0;
-         coeres->command += COE_COMMAND_LASTSEGMENTBIT;
+         coeres->command |= COE_COMMAND_LASTSEGMENTBIT;
          if (size >= 7)
          {
             coeres->mbxheader.length = htoes (COE_SEGMENTHEADERSIZE + size);
          }
          else
          {
-            coeres->command += (7 - size) << 1;
+            coeres->command |= (uint8_t)((7U - size) << 1);
             coeres->mbxheader.length = htoes (COE_DEFAULTLENGTH);
          }
       }
@@ -768,9 +773,10 @@ static void SDO_download (void)
    _COEsdo *coesdo, *coeres;
    uint16_t index;
    uint8_t subindex;
-   int16_t nidx, nsub;
+   int32_t nidx;
+   int16_t nsub;
    uint8_t MBXout;
-   uint16_t size, actsize;
+   uint32_t size, actsize;
    const _objd *objd;
    uint32_t *mbxdata;
    uint32_t abort;
@@ -792,7 +798,7 @@ static void SDO_download (void)
             /* expedited? */
             if (coesdo->command & COE_EXPEDITED_INDICATOR)
             {
-               size = 4 - ((coesdo->command & 0x0c) >> 2);
+               size = 4U - ((coesdo->command & 0x0CU) >> 2);
                mbxdata = &(coesdo->size);
             }
             else
@@ -914,7 +920,8 @@ static void SDO_download_complete_access (void)
    _COEsdo *coesdo = (_COEsdo *) &MBX[0];
    uint16_t index;
    uint8_t subindex;
-   int16_t nidx, nsub;
+   int32_t nidx;
+   int16_t nsub;
    uint32_t abortcode = complete_access_get_variables
                            (coesdo, &index, &subindex, &nidx, &nsub);
    if (abortcode != 0)
@@ -929,7 +936,7 @@ static void SDO_download_complete_access (void)
    if (coesdo->command & COE_EXPEDITED_INDICATOR)
    {
       /* expedited download */
-      bytes = 4 - ((coesdo->command & 0x0c) >> 2);
+      bytes = 4U - ((coesdo->command & 0x0CU) >> 2);
    }
    else
    {
@@ -1030,13 +1037,14 @@ static void SDO_downloadsegment (void)
    if (MBXout)
    {
       _COEsdo *coeres = (_COEsdo *) &MBX[MBXout * ESC_MBXSIZE];
-      uint32_t size = coesdo->mbxheader.length - 3;
+      uint32_t size = coesdo->mbxheader.length - 3U;
       if (size == 7)
       {
          size = 7 - ((coesdo->command >> 1) & 7);
       }
-      uint8_t command = COE_COMMAND_DOWNLOADSEGRESP +
-            (coesdo->command & COE_TOGGLEBIT);  /* copy toggle bit */
+      uint8_t command = COE_COMMAND_DOWNLOADSEGRESP;
+      uint8_t command2 = (coesdo->command & COE_TOGGLEBIT);  /* copy toggle bit */
+      command |= command2;
       init_coesdo(coeres, COE_SDORESPONSE, command, 0, 0);
 
       void *mbxdata = &(coesdo->index);  /* data pointer */
@@ -1046,7 +1054,8 @@ static void SDO_downloadsegment (void)
       {
          if(ESCvar.flags == COMPLETE_ACCESS_FLAG)
          {
-            int16_t nidx, nsub;
+            int32_t nidx;
+            int16_t nsub;
 
             if(ESCvar.frags > ESCvar.fragsleft + size)
             {
@@ -1112,7 +1121,7 @@ static void SDO_infoerror (uint32_t abortcode)
    if (MBXout)
    {
       coeres = (_COEobjdesc *) &MBX[MBXout * ESC_MBXSIZE];
-      coeres->mbxheader.length = htoes ((uint16_t) COE_HEADERSIZE);
+      coeres->mbxheader.length = htoes (COE_HEADERSIZE);
       coeres->mbxheader.mbxtype = MBXCOE;
       coeres->coeheader.numberservice =
          htoes ((0 & 0x01f) | (COE_SDOINFORMATION << 12));
@@ -1129,14 +1138,14 @@ static void SDO_infoerror (uint32_t abortcode)
    }
 }
 
-#define ODLISTSIZE  ((ESC_MBX1_sml - ESC_MBXHSIZE - sizeof(_COEh) - sizeof(_INFOh) - 2) & 0xfffe)
+#define ODLISTSIZE  ((uint32_t)(ESC_MBX1_sml - ESC_MBXHSIZE - sizeof(_COEh) - sizeof(_INFOh) - 2U) & 0xfffe)
 
 /** Function for handling incoming requested SDO Get OD List, validating the
  * request and sending an response. On error an SDO Info Error will be sent.
  */
 static void SDO_getodlist (void)
 {
-   uint16_t frags;
+   uint32_t frags;
    uint8_t MBXout = 0;
    uint16_t entries = 0;
    uint16_t i, n;
@@ -1148,7 +1157,7 @@ static void SDO_getodlist (void)
       entries++;
    }
    ESCvar.entries = entries;
-   frags = ((entries << 1) + ODLISTSIZE - 1);
+   frags = ((uint32_t)(entries << 1) + ODLISTSIZE - 1U);
    frags /= ODLISTSIZE;
    coer = (_COEobjdesc *) &MBX[0];
    /* check for unsupported opcodes */
@@ -1170,10 +1179,10 @@ static void SDO_getodlist (void)
       /* number of objects request */
       if (etohs (coer->index) == 0x00)
       {
-         coel->index = htoes ((uint16_t) 0x00);
+         coel->index = htoes (0x00);
          coel->infoheader.incomplete = 0;
          coel->infoheader.reserved = 0x00;
-         coel->infoheader.fragmentsleft = htoes ((uint16_t) 0);
+         coel->infoheader.fragmentsleft = htoes (0);
          MBXcontrol[0].state = MBXstate_idle;
          ESCvar.xoe = 0;
          ESCvar.frags = frags;
@@ -1210,7 +1219,7 @@ static void SDO_getodlist (void)
          ESCvar.frags = frags;
          ESCvar.fragsleft = frags - 1;
          coel->infoheader.fragmentsleft = htoes (ESCvar.fragsleft);
-         coel->index = htoes ((uint16_t) 0x01);
+         coel->index = htoes (0x01);
 
          p = &(coel->datatype);
          for (i = 0; i < n; i++)
@@ -1240,13 +1249,13 @@ static void SDO_getodlistcont (void)
       coel = (_COEobjdesc *) &MBX[MBXout * ESC_MBXSIZE];
       coel->mbxheader.mbxtype = MBXCOE;
       coel->coeheader.numberservice =
-         htoes ((0 & 0x01f) | (COE_SDOINFORMATION << 12));
+         htoes (COE_SDOINFORMATION << 12);
       coel->infoheader.opcode = COE_GETODLISTRESPONSE;
-      s = (ESCvar.frags - ESCvar.fragsleft) * (ODLISTSIZE >> 1);
+      s = (uint16_t)((ESCvar.frags - ESCvar.fragsleft) * (ODLISTSIZE >> 1));
       if (ESCvar.fragsleft > 1)
       {
          coel->infoheader.incomplete = 1;
-         n = s + (ODLISTSIZE >> 1);
+         n = (uint16_t)(s + (ODLISTSIZE >> 1));
       }
       else
       {
@@ -1257,7 +1266,7 @@ static void SDO_getodlistcont (void)
       }
       coel->infoheader.reserved = 0x00;
       ESCvar.fragsleft--;
-      coel->infoheader.fragmentsleft = htoes (ESCvar.fragsleft);
+      coel->infoheader.fragmentsleft = htoes ((uint16_t)ESCvar.fragsleft);
       /* pointer 2 bytes back to exclude index */
       p = &(coel->index);
       for (i = s; i < n; i++)
@@ -1294,7 +1303,7 @@ static void SDO_getod (void)
          coel = (_COEobjdesc *) &MBX[MBXout * ESC_MBXSIZE];
          coel->mbxheader.mbxtype = MBXCOE;
          coel->coeheader.numberservice =
-            htoes ((0 & 0x01f) | (COE_SDOINFORMATION << 12));
+            htoes (COE_SDOINFORMATION << 12);
          coel->infoheader.opcode = COE_GETODRESPONSE;
          coel->infoheader.incomplete = 0;
          coel->infoheader.reserved = 0x00;
@@ -1312,14 +1321,14 @@ static void SDO_getod (void)
             int32_t nsub = SDO_findsubindex (nidx, 0);
             const _objd *objd = SDOobjects[nidx].objdesc;
             coel->datatype = htoes ((objd + nsub)->datatype);
-            coel->maxsub = SDOobjects[nidx].objdesc->value;
+            coel->maxsub = (uint8_t)SDOobjects[nidx].objdesc->value;
          }
          else
          {
             coel->datatype = htoes (0);
-            coel->maxsub = SDOobjects[nidx].objdesc->value;
+            coel->maxsub = (uint8_t)SDOobjects[nidx].objdesc->value;
          }
-         coel->objectcode = SDOobjects[nidx].objtype;
+         coel->objectcode = (uint8_t)SDOobjects[nidx].objtype;
          s = (uint8_t *) SDOobjects[nidx].name;
          d = (uint8_t *) &(coel->name);
          while (*s && (n < (ESC_MBXDSIZE - 0x0c)))
@@ -1330,7 +1339,7 @@ static void SDO_getod (void)
             d++;
          }
          *d = *s;
-         coel->mbxheader.length = htoes ((uint16_t) 0x0c + n);
+         coel->mbxheader.length = htoes (0x0C + n);
          MBXcontrol[MBXout].state = MBXstate_outreq;
          MBXcontrol[0].state = MBXstate_idle;
          ESCvar.xoe = 0;
@@ -1350,7 +1359,8 @@ static void SDO_geted (void)
 {
    uint8_t MBXout;
    uint16_t index;
-   int32_t nidx, nsub;
+   int32_t nidx;
+   int16_t nsub;
    uint8_t subindex;
    uint8_t *d;
    const uint8_t *s;
@@ -1377,7 +1387,7 @@ static void SDO_geted (void)
             coel->infoheader.opcode = COE_ENTRYDESCRIPTIONRESPONSE;
             coel->infoheader.incomplete = 0;
             coel->infoheader.reserved = 0x00;
-            coel->infoheader.fragmentsleft = htoes ((uint16_t) 0);
+            coel->infoheader.fragmentsleft = htoes (0);
             coel->index = htoes (index);
             coel->subindex = subindex;
             coel->valueinfo = COE_VALUEINFO_ACCESS +
@@ -1395,7 +1405,7 @@ static void SDO_geted (void)
                d++;
             }
             *d = *s;
-            coel->mbxheader.length = htoes ((uint16_t) 0x10 + n);
+            coel->mbxheader.length = htoes (0x10 + n);
             MBXcontrol[MBXout].state = MBXstate_outreq;
             MBXcontrol[0].state = MBXstate_idle;
             ESCvar.xoe = 0;
@@ -1421,7 +1431,7 @@ void ESC_coeprocess (void)
    _MBXh *mbh;
    _COEsdo *coesdo;
    _COEobjdesc *coeobjdesc;
-   uint8_t service;
+   uint16_t service;
    if (ESCvar.MBXrun == 0)
    {
       return;
@@ -1548,10 +1558,10 @@ void ESC_coeprocess (void)
  * @param[in] length = number of bits to get
  * @return bitslice value
  */
-static uint64_t COE_bitsliceGet (uint64_t * bitmap, int offset, int length)
+static uint64_t COE_bitsliceGet (uint64_t * bitmap, unsigned int offset, unsigned int length)
 {
-   const int word_offset = offset / 64;
-   const int bit_offset = offset % 64;
+   const unsigned int word_offset = offset / 64;
+   const unsigned int bit_offset = offset % 64;
    const uint64_t mask = (length == 64) ? UINT64_MAX : (1ULL << length) - 1;
    uint64_t w0;
    uint64_t w1 = 0;
@@ -1581,11 +1591,11 @@ static uint64_t COE_bitsliceGet (uint64_t * bitmap, int offset, int length)
  * @param[in] length = number of bits to set
  * @param[in] value  = value to set
  */
-static void COE_bitsliceSet (uint64_t * bitmap, int offset, int length,
+static void COE_bitsliceSet (uint64_t * bitmap, unsigned int offset, unsigned int length,
                              uint64_t value)
 {
-   const int word_offset = offset / 64;
-   const int bit_offset = offset % 64;
+   const unsigned int word_offset = offset / 64;
+   const unsigned int bit_offset = offset % 64;
    const uint64_t mask = (length == 64) ? UINT64_MAX : (1ULL << length) - 1;
    const uint64_t mask0 = mask << bit_offset;
    uint64_t v0 = value << bit_offset;
@@ -1778,7 +1788,7 @@ void COE_pdoPack (uint8_t * buffer, int nmappings, _SMmap * mappings)
    for (ix = 0; ix < nmappings; ix++)
    {
       const _objd * obj = mappings[ix].obj;
-      uint16_t offset = mappings[ix].offset;
+      uint32_t offset = mappings[ix].offset;
 
       if (obj != NULL)
       {
@@ -1825,7 +1835,7 @@ void COE_pdoUnpack (uint8_t * buffer, int nmappings, _SMmap * mappings)
    for (ix = 0; ix < nmappings; ix++)
    {
       const _objd * obj = mappings[ix].obj;
-      uint16_t offset = mappings[ix].offset;
+      uint32_t offset = mappings[ix].offset;
 
       if (obj != NULL)
       {
@@ -1860,7 +1870,7 @@ void COE_pdoUnpack (uint8_t * buffer, int nmappings, _SMmap * mappings)
  */
 uint8_t COE_maxSub (uint16_t index)
 {
-   int nidx;
+   int32_t nidx;
    uint8_t maxsub;
 
    nidx = SDO_findobject (index);

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -41,7 +41,7 @@ typedef struct
 {
    const _objd * obj;
    const _objectlist * objectlistitem;
-   uint16_t offset;
+   uint32_t offset;
 } _SMmap;
 
 #define OBJH_READ               0
@@ -112,7 +112,7 @@ typedef struct
 #define COMPLETE_ACCESS_FLAG    (1 << 15)
 
 void ESC_coeprocess (void);
-int16_t SDO_findsubindex (int16_t nidx, uint8_t subindex);
+int16_t SDO_findsubindex (int32_t nidx, uint8_t subindex);
 int32_t SDO_findobject (uint16_t index);
 uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * sm, int max_mappings);
 void COE_initDefaultValues (void);

--- a/soes/esc_eep.c
+++ b/soes/esc_eep.c
@@ -53,7 +53,7 @@ void EEP_process (void)
          case EEP_CMD_READ:
          case EEP_CMD_RELOAD:
             /* handle read request */
-            if (EEP_read (stat.addr * sizeof(uint16_t), eep_buf, EEP_READ_SIZE) != 0) {
+            if (EEP_read (stat.addr * 2U /* sizeof(uint16_t) */, eep_buf, EEP_READ_SIZE) != 0) {
                stat.contstat.bits.ackErr = 1;
             } else {
                ESC_write (ESCREG_EEDATA, eep_buf, EEP_READ_SIZE);
@@ -63,7 +63,7 @@ void EEP_process (void)
          case EEP_CMD_WRITE:
             /* handle write request */
             ESC_read (ESCREG_EEDATA, eep_buf, EEP_WRITE_SIZE);
-            if (EEP_write (stat.addr * sizeof(uint16_t), eep_buf, EEP_WRITE_SIZE) != 0) {
+            if (EEP_write (stat.addr * 2U /* sizeof(uint16_t) */, eep_buf, EEP_WRITE_SIZE) != 0) {
                stat.contstat.bits.ackErr = 1;
             }
             break;

--- a/soes/esc_eoe.c
+++ b/soes/esc_eoe.c
@@ -109,7 +109,7 @@
 /** Ethernet address length not including VLAN */
 #define EOE_ETHADDR_LENGTH    6
 /** IPv4 address length */
-#define EOE_IP4_LENGTH        sizeof(uint32_t)
+#define EOE_IP4_LENGTH        4U /* sizeof(uint32_t) */
 
 /** EOE ip4 address in network order */
 struct eoe_ip4_addr {

--- a/soes/esc_foe.c
+++ b/soes/esc_foe.c
@@ -50,7 +50,7 @@ static _FOEvar FOEvar;
  * @return 0= if we succeed, FOE_ERR_NOTFOUND something wrong with filename or
  * password
  */
-static int FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
+static uint32_t FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
 {
    uint32_t i;
 
@@ -118,9 +118,9 @@ static int FOE_fopen (char *name, uint8_t num_chars, uint32_t pass, uint8_t op)
 
  * @return Number of copied bytes.
  */
-static uint16_t FOE_fread (uint8_t * data, uint16_t maxlength)
+static uint32_t FOE_fread (uint8_t * data, uint32_t maxlength)
 {
-   uint16_t ncopied = 0;
+   uint32_t ncopied = 0;
 
    while (maxlength && (FOEvar.fend - FOEvar.fposition))
    {
@@ -144,9 +144,9 @@ static uint16_t FOE_fread (uint8_t * data, uint16_t maxlength)
 
  * @return Number of copied bytes.
  */
-static uint16_t FOE_fwrite (uint8_t *data, uint16_t length)
+static uint32_t FOE_fwrite (uint8_t *data, uint32_t length)
 {
-    uint16_t ncopied = 0;
+    uint32_t ncopied = 0;
     uint32_t failed = 0;
 
     DPRINT("FOE_fwrite\n");
@@ -249,10 +249,10 @@ static void FOE_abort (uint32_t code)
  * @return Number of data bytes written or an error number. Error numbers
  * will be greater than FOE_DATA_SIZE.
  */
-static int FOE_send_data_packet ()
+static uint32_t FOE_send_data_packet ()
 {
    _FOE *foembx;
-   uint16_t data_len;
+   uint32_t data_len;
    uint8_t mbxhandle;
 
    mbxhandle = ESC_claimbuffer ();
@@ -280,7 +280,7 @@ static int FOE_send_data_packet ()
 
  * @return 0= or error number.
  */
-static int FOE_send_ack ()
+static uint32_t FOE_send_ack ()
 {
    _FOE *foembx;
    uint8_t mbxhandle;
@@ -316,9 +316,9 @@ static int FOE_send_ack ()
 static void FOE_read ()
 {
    _FOE *foembx;
-   uint32_t data_len;
    uint32_t password;
-   int res;
+   uint32_t res;
+   uint8_t data_len;
 
    if (FOEvar.foestate != FOE_READY)
    {
@@ -329,7 +329,7 @@ static void FOE_read ()
    FOE_init ();
    foembx = (_FOE *) &MBX[0];
    /* Get the length of the file name in octets. */
-   data_len = etohs (foembx->mbxheader.length) - ESC_FOEHSIZE;
+   data_len = (uint8_t)(etohs (foembx->mbxheader.length) - ESC_FOEHSIZE);
    password = etohl (foembx->foeheader.password);
 
    res = FOE_fopen (foembx->filename, data_len, password, FOE_OP_RRQ);
@@ -340,7 +340,7 @@ static void FOE_read ()
        * Attempt to send the packet
        */
       res = FOE_send_data_packet ();
-      if (res <= (int)ESC_FOE_DATA_SIZE)
+      if (res <= ESC_FOE_DATA_SIZE)
       {
          FOEvar.foestate = FOE_WAIT_FOR_ACK;
       }
@@ -360,7 +360,7 @@ static void FOE_read ()
  */
 static void FOE_ack ()
 {
-   int res;
+   uint32_t res;
 
    /* Make sure we're able to take this. */
    if (FOEvar.foestate == FOE_WAIT_FOR_FINAL_ACK)
@@ -375,7 +375,7 @@ static void FOE_ack ()
       return;
    }
    res = FOE_send_data_packet ();
-   if (res < (int)ESC_FOE_DATA_SIZE)
+   if (res < ESC_FOE_DATA_SIZE)
    {
       FOEvar.foestate = FOE_WAIT_FOR_FINAL_ACK;
    }
@@ -393,9 +393,9 @@ static void FOE_ack ()
 static void FOE_write ()
 {
    _FOE *foembx;
-   uint32_t data_len;
    uint32_t password;
-   int res;
+   uint32_t res;
+   uint8_t data_len;
 
    if (FOEvar.foestate != FOE_READY)
    {
@@ -405,7 +405,7 @@ static void FOE_write ()
 
    FOE_init ();
    foembx = (_FOE *) &MBX[0];
-   data_len = etohs (foembx->mbxheader.length) - ESC_FOEHSIZE;
+   data_len = (uint8_t)(etohs (foembx->mbxheader.length) - ESC_FOEHSIZE);
    password = etohl (foembx->foeheader.password);
 
    /* Get an address we can write the file to, if possible. */
@@ -436,8 +436,8 @@ static void FOE_data ()
 {
    _FOE *foembx;
    uint32_t packet;
-   uint16_t data_len, ncopied;
-   int res;
+   uint32_t data_len, ncopied;
+   uint32_t res;
 
    if(FOEvar.foestate != FOE_WAIT_FOR_DATA)
    {

--- a/soes/include/sys/gcc/cc.h
+++ b/soes/include/sys/gcc/cc.h
@@ -54,11 +54,11 @@ extern "C"
 #define CC_ATOMIC_OR(var,val)    __atomic_or_fetch(&var,val,__ATOMIC_SEQ_CST)
 
 #if BYTE_ORDER == BIG_ENDIAN
-#define htoes(x) CC_SWAP16 (x)
-#define htoel(x) CC_SWAP32 (x)
+#define htoes(x) CC_SWAP16 ((uint16_t)(x))
+#define htoel(x) CC_SWAP32 ((uint32_t)(x))
 #else
-#define htoes(x) (x)
-#define htoel(x) (x)
+#define htoes(x) ((uint16_t)(x))
+#define htoel(x) ((uint32_t)(x))
 #endif
 
 #define etohs(x) htoes (x)


### PR DESCRIPTION
Fix warnings for Wconversion

Approach

- Try to align types if there was an obvious mismatch
- Internal variables that don't reflect any HW or Protocol member, will be increase to size_t or uint32_t to avoid integer promotion
- Do bitwise operation instead of arithmetic to avoid integer promotion
- Last make an explicit type cast

fixes #148
