### PR TITLE
Fix Wconversion issues for clang

### DIFF
--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -299,7 +299,7 @@ static void SDO_upload (void)
    uint16_t index;
    uint8_t subindex;
    int32_t nidx;
-   int32_t nsub;
+   int16_t nsub;
    uint8_t MBXout;
    uint32_t size;
    uint8_t dss;

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -171,7 +171,10 @@ uint16_t sizeOfPDO (uint16_t index, int * nmappings, _SMmap * mappings,
                      return 0;
                   }
 
-                  DPRINT ("%04x:%02x @ %d\n", index, subindex, offset);
+                  DPRINT ("%04"PRIx32":%02"PRIx32" @ %"PRIu32"\n",
+                        index,
+                        subindex,
+                        offset);
 
                   if (index == 0 && subindex == 0)
                   {
@@ -1756,7 +1759,10 @@ void COE_initDefaultValues (void)
          if (objd[i].data != NULL)
          {
             COE_setValue (&objd[i], objd[i].value);
-            DPRINT ("%04x:%02x = %x\n", SDOobjects[n].index, objd[i].subindex, objd[i].value);
+            DPRINT ("%04"PRIx32":%02"PRIx32" = %"PRIx32"\n",
+                  SDOobjects[n].index,
+                  objd[i].subindex,
+                  objd[i].value);
          }
       } while (objd[i++].subindex < maxsub);
    }

--- a/soes/esc_eoe.c
+++ b/soes/esc_eoe.c
@@ -738,7 +738,7 @@ static void EOE_receive_fragment (void)
    /* Capture error case */
    if(EOEvar.rxfragmentno != EOE_HDR_FRAG_NO_GET(frameinfo2))
    {
-      DPRINT("Unexpected fragment number %u, expected: %u\n",
+      DPRINT("Unexpected fragment number %"PRIu32", expected: %"PRIu32"\n",
             EOE_HDR_FRAG_NO_GET(frameinfo2), EOEvar.rxfragmentno);
       /* Clean up existing saved data */
       if(EOEvar.rxfragmentno != 0)
@@ -777,14 +777,14 @@ static void EOE_receive_fragment (void)
       /* Validate received fragment */
       if(EOEvar.rxframeno != EOE_HDR_FRAME_NO_GET(frameinfo2))
       {
-         DPRINT("Unexpected frame number %u, expected: %u\n",
+         DPRINT("Unexpected frame number %"PRIu32", expected: %"PRIu32"\n",
                EOE_HDR_FRAME_NO_GET(frameinfo2), EOEvar.rxframeno);
          EOE_init_rx ();
          return;
       }
       else if(EOEvar.rxframeoffset != offset)
       {
-         DPRINT("Unexpected frame offset %u, expected: %u\n",
+         DPRINT("Unexpected frame offset %"PRIu32", expected: %"PRIu32"\n",
                offset, EOEvar.rxframeoffset);
          EOE_init_rx ();
          return;

--- a/soes/esc_eoe.c
+++ b/soes/esc_eoe.c
@@ -47,37 +47,37 @@
 /** Header frame info 1 */
 #define EOE_HDR_FRAME_TYPE_OFFSET      0
 #define EOE_HDR_FRAME_TYPE             (0xF << 0)
-#define EOE_HDR_FRAME_TYPE_SET(x)      (((x) & 0xF) << 0)
+#define EOE_HDR_FRAME_TYPE_SET(x)      ((uint16_t)(((x) & 0xF) << 0))
 #define EOE_HDR_FRAME_TYPE_GET(x)      (((x) >> 0) & 0xF)
 #define EOE_HDR_FRAME_PORT_OFFSET      4
 #define EOE_HDR_FRAME_PORT             (0xF << 4)
-#define EOE_HDR_FRAME_PORT_SET(x)      (((x) & 0xF) << 4)
+#define EOE_HDR_FRAME_PORT_SET(x)      ((uint16_t)(((x) & 0xF) << 4))
 #define EOE_HDR_FRAME_PORT_GET(x)      (((x) >> 4) & 0xF)
 #define EOE_HDR_LAST_FRAGMENT_OFFSET   8
 #define EOE_HDR_LAST_FRAGMENT          (0x1 << 8)
-#define EOE_HDR_LAST_FRAGMENT_SET(x)   (((x) & 0x1) << 8)
+#define EOE_HDR_LAST_FRAGMENT_SET(x)   ((uint16_t)(((x) & 0x1) << 8))
 #define EOE_HDR_LAST_FRAGMENT_GET(x)   (((x) >> 8) & 0x1)
 #define EOE_HDR_TIME_APPEND_OFFSET     9
 #define EOE_HDR_TIME_APPEND            (0x1 << 9)
-#define EOE_HDR_TIME_APPEND_SET(x)     (((x) & 0x1) << 9)
+#define EOE_HDR_TIME_APPEND_SET(x)     ((uint16_t)(((x) & 0x1) << 9))
 #define EOE_HDR_TIME_APPEND_GET(x)     (((x) >> 9) & 0x1)
 #define EOE_HDR_TIME_REQUEST_OFFSET    10
 #define EOE_HDR_TIME_REQUEST           (0x1 << 10)
-#define EOE_HDR_TIME_REQUEST_SET(x)    (((x) & 0x1) << 10)
+#define EOE_HDR_TIME_REQUEST_SET(x)    ((uint16_t)(((x) & 0x1) << 10))
 #define EOE_HDR_TIME_REQUEST_GET(x)    (((x) >> 10) & 0x1)
 
 /** Header frame info 2 */
 #define EOE_HDR_FRAG_NO_OFFSET         0
 #define EOE_HDR_FRAG_NO                (0x3F << 0)
-#define EOE_HDR_FRAG_NO_SET(x)         (((x) & 0x3F) << 0)
+#define EOE_HDR_FRAG_NO_SET(x)         ((uint16_t)(((x) & 0x3F) << 0))
 #define EOE_HDR_FRAG_NO_GET(x)         (((x) >> 0) & 0x3F)
 #define EOE_HDR_FRAME_OFFSET_OFFSET    6
 #define EOE_HDR_FRAME_OFFSET           (0x3F << 6)
-#define EOE_HDR_FRAME_OFFSET_SET(x)    (((x) & 0x3F) << 6)
+#define EOE_HDR_FRAME_OFFSET_SET(x)    ((uint16_t)(((x) & 0x3F) << 6))
 #define EOE_HDR_FRAME_OFFSET_GET(x)    (((x) >> 6) & 0x3F)
 #define EOE_HDR_FRAME_NO_OFFSET        12
 #define EOE_HDR_FRAME_NO               (0xF << 12)
-#define EOE_HDR_FRAME_NO_SET(x)        (((x) & 0xF) << 12)
+#define EOE_HDR_FRAME_NO_SET(x)        ((uint16_t)(((x) & 0xF) << 12))
 #define EOE_HDR_FRAME_NO_GET(x)        (((x) >> 12) & 0xF)
 
 /** EOE param */
@@ -738,7 +738,7 @@ static void EOE_receive_fragment (void)
    /* Capture error case */
    if(EOEvar.rxfragmentno != EOE_HDR_FRAG_NO_GET(frameinfo2))
    {
-      DPRINT("Unexpected fragment number %d, expected: %d\n",
+      DPRINT("Unexpected fragment number %u, expected: %u\n",
             EOE_HDR_FRAG_NO_GET(frameinfo2), EOEvar.rxfragmentno);
       /* Clean up existing saved data */
       if(EOEvar.rxfragmentno != 0)
@@ -773,18 +773,18 @@ static void EOE_receive_fragment (void)
    /* In frame fragment received */
    else
    {
-      uint16_t offset = (EOE_HDR_FRAME_OFFSET_GET(frameinfo2) << 5);
+      uint32_t offset = (EOE_HDR_FRAME_OFFSET_GET(frameinfo2) << 5);
       /* Validate received fragment */
       if(EOEvar.rxframeno != EOE_HDR_FRAME_NO_GET(frameinfo2))
       {
-         DPRINT("Unexpected frame number %d, expected: %d\n",
+         DPRINT("Unexpected frame number %u, expected: %u\n",
                EOE_HDR_FRAME_NO_GET(frameinfo2), EOEvar.rxframeno);
          EOE_init_rx ();
          return;
       }
       else if(EOEvar.rxframeoffset != offset)
       {
-         DPRINT("Unexpected frame offset %d, expected: %d\n",
+         DPRINT("Unexpected frame offset %u, expected: %u\n",
                offset, EOEvar.rxframeoffset);
          EOE_init_rx ();
          return;
@@ -890,7 +890,7 @@ static void EOE_send_fragment ()
       }
 
       /* Set frame number */
-      tempframe2 = (uint16_t)EOE_HDR_FRAME_NO_SET(frameno);
+      tempframe2 = EOE_HDR_FRAME_NO_SET(frameno);
       frameinfo2 |= tempframe2;
 
       eoembx = (_EOE *) &MBX[mbxhandle * ESC_MBXSIZE];

--- a/soes/esc_foe.c
+++ b/soes/esc_foe.c
@@ -164,7 +164,7 @@ static uint32_t FOE_fwrite (uint8_t *data, uint32_t length)
        FOEvar.fposition++;
        if(failed)
        {
-          DPRINT("Failed FOE_fwrite ncopied=%d\n", ncopied);
+          DPRINT("Failed FOE_fwrite ncopied=%"PRIu32"\n", ncopied);
        }
        else
        {
@@ -174,7 +174,7 @@ static uint32_t FOE_fwrite (uint8_t *data, uint32_t length)
 
     foe_file->total_size += ncopied;
 
-    DPRINT("FOE_fwrite END with : %d\n",ncopied);
+    DPRINT("FOE_fwrite END with : %"PRIu32"\n",ncopied);
     return ncopied;
 }
 
@@ -234,7 +234,7 @@ static void FOE_abort (uint32_t code)
       }
       /* Nothing we can do if we can't get an outbound mailbox. */
    }
-   DPRINT("FOE_abort: 0x%X\n", code);
+   DPRINT("FOE_abort: 0x%"PRIX32"\n", code);
    FOE_init ();
 }
 
@@ -451,7 +451,9 @@ static void FOE_data ()
 
    if (packet != FOEvar.foepacket)
    {
-      DPRINT("FOE_data packet error, packet: %d, foeheader.packet: %d\n",packet,FOEvar.foepacket);
+      DPRINT("FOE_data packet error, packet: %"PRIu32", foeheader.packet: %"PRIu32"\n",
+            packet,
+            FOEvar.foepacket);
       FOE_abort (FOE_ERR_PACKETNO);
    }
    else if (data_len == 0)
@@ -479,7 +481,7 @@ static void FOE_data ()
          DPRINT("FOE_data data_len == FOE_DATA_SIZE\n");
          if (ncopied != data_len)
          {
-            DPRINT("FOE_data only %d of %d copied\n",ncopied, data_len);
+            DPRINT("FOE_data only %"PRIu32" of %"PRIu32" copied\n",ncopied, data_len);
             FOE_abort (FOE_ERR_PROGERROR);
          }
          res = FOE_send_ack ();

--- a/soes/include/sys/gcc/cc.h
+++ b/soes/include/sys/gcc/cc.h
@@ -14,6 +14,7 @@ extern "C"
 #include <assert.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <inttypes.h>
 #include <sys/param.h>
 #ifdef __linux__
    #include <endian.h>
@@ -35,6 +36,7 @@ extern "C"
 #define CC_ALIGNED(n)   __attribute__((aligned (n)))
 
 #ifdef __rtk__
+#include <kern/assert.h>
 #define CC_ASSERT(exp) ASSERT (exp)
 #else
 #define CC_ASSERT(exp) assert (exp)
@@ -70,9 +72,10 @@ extern "C"
 #define EC_BIG_ENDIAN
 #endif
 
+#define ESC_DEBUG
 #ifdef ESC_DEBUG
 #ifdef __rtk__
-#include <rprint.h>
+#include <kern/rprint.h>
 #define DPRINT(...) rprintp ("soes: "__VA_ARGS__)
 #else
 #include <stdio.h>


### PR DESCRIPTION
Add explicit uint16_t cast for EoE header SET macros. Used for SET of FrameInfo 1 and FrameInfo 2.

Increase datatype for offset used by EOE_HDR_FRAME_OFFSET_GET.

Change debug print formatting to %u for unsigned datatypes.


