### PR TITLE
Sync local SM PDIreg with ESC PDIreg at Mbx start

### DIFF
--- a/soes/esc.c
+++ b/soes/esc.c
@@ -334,6 +334,8 @@ uint8_t ESC_startmbx (uint8_t state)
    else
    {
       ESCvar.toggle = ESCvar.SM[1].ECrep;       //sync repeat request toggle state
+      ESCvar.SM[1].PDIrep = ESCvar.toggle & 0x1U;
+      ESC_SMwritepdi (1);
       ESCvar.MBXrun = 1;
    }
    return state;
@@ -367,6 +369,8 @@ uint8_t ESC_startmbxboot (uint8_t state)
    else
    {
       ESCvar.toggle = ESCvar.SM[1].ECrep;       //sync repeat request toggle state
+      ESCvar.SM[1].PDIrep = ESCvar.toggle & 0x1U;
+      ESC_SMwritepdi (1);
       ESCvar.MBXrun = 1;
    }
    return state;


### PR DESCRIPTION
When starting mailbox service, write the value of
ECAT RepeatRequest to PDI RepeatAck. Otherwise
it is risk of a race condition when running
CTT and the repeat ack would hold the value
of previous repeat ack test.

The race condition occurs on slow targets
that doesn't handle the repeat request
fast enough. The resulting mailbox read
will come before the mailbox is emptied
on the SM changed event.

fixes #169 


