### PR TITLE
Move fbuffer and buffer_size from foe_file_cfg to foe_cfg

### DIFF
--- a/soes/esc_foe.c
+++ b/soes/esc_foe.c
@@ -125,7 +125,7 @@ static uint32_t FOE_fread (uint8_t * data, uint32_t maxlength)
    while (maxlength && (FOEvar.fend - FOEvar.fposition))
    {
       maxlength--;
-      *(data++) = foe_cfg->fbuffer[FOEvar.fposition++];
+      *(data++) = foe_file->fbuffer[FOEvar.fposition++];
       ncopied++;
    }
 
@@ -154,12 +154,12 @@ static uint32_t FOE_fwrite (uint8_t *data, uint32_t length)
     while (length && (FOEvar.fend - FOEvar.fposition) && !failed)
     {
        length--;
-       foe_cfg->fbuffer[FOEvar.fbufposition++] = *(data++);
-       if(FOEvar.fbufposition >= foe_cfg->buffer_size)
+       foe_file->fbuffer[FOEvar.fbufposition++] = *(data++);
+       if(FOEvar.fbufposition >= foe_file->buffer_size)
        {
-          failed = foe_file->write_function (foe_file, foe_cfg->fbuffer, FOEvar.fbufposition);
+          failed = foe_file->write_function (foe_file, foe_file->fbuffer, FOEvar.fbufposition);
           FOEvar.fbufposition = 0;
-          foe_file->address_offset += foe_cfg->buffer_size;
+          foe_file->address_offset += foe_file->buffer_size;
        }
        FOEvar.fposition++;
        if(failed)
@@ -190,7 +190,7 @@ static uint32_t FOE_fclose (void)
 
    DPRINT("FOE_fclose\n");
    
-   failed = foe_file->write_function (foe_file, foe_cfg->fbuffer, FOEvar.fbufposition);
+   failed = foe_file->write_function (foe_file, foe_file->fbuffer, FOEvar.fbufposition);
    foe_file->address_offset += FOEvar.fbufposition;
    FOEvar.fbufposition = 0;
 

--- a/soes/esc_foe.h
+++ b/soes/esc_foe.h
@@ -23,6 +23,10 @@ struct foe_file_cfg
    const char * name;
    /** Size of file,sizeof data we can recv */
    uint32_t       max_data;
+   /** Allocate static in caller func to fit buffer_size */
+   uint8_t * fbuffer;
+   /** Buffer size before we flush to destination */
+   uint32_t  buffer_size;
    /** Where to store the data initially */
    uint32_t       dest_start_address;
    /** Current address during write of file */
@@ -41,10 +45,6 @@ struct foe_file_cfg
 
 typedef struct foe_cfg
 {
-   /** Allocate static in caller func to fit buffer_size */
-   uint8_t * fbuffer;
-   /** Buffer size before we flush to destination */
-   uint32_t  buffer_size;
    /** Number of files used in firmware update */
    uint32_t  n_files;
    /** Pointer to files configured to be used by FoE */


### PR DESCRIPTION
This allowing read and writing with multiple files. Mainly for reading since we can use the same buffer for different writing operations.