### PR TITLE
fix: Limit mailbox length

### DIFF
--- a/soes/esc.c
+++ b/soes/esc.c
@@ -3,13 +3,12 @@
  * LICENSE file in the project root for full license information
  */
 #include <string.h>
-#include <assert.h>
 #include <cc.h>
 #include "esc.h"
 #include "esc_coe.h"
 #include "esc_foe.h"
 
-static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
+CC_STATIC_ASSERT((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
 
 /** \file
  * \brief

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -658,7 +658,7 @@ uint8_t ESC_mbxprocess (void)
    {
       ESC_readmbx ();
       ESCvar.SM[0].MBXstat = 0;
-      if (etohs (MBh->length) == 0)
+      if ((etohs (MBh->length) == 0) || (etohs (MBh->length) > (ESC_MBX0_sml - ESC_MBXHSIZE)))
       {
          MBX_error (MBXERR_INVALIDHEADER);
          /* drop mailbox */
@@ -712,7 +712,7 @@ uint8_t ESC_checkSM23 (uint8_t state)
    _ESCsm2 *SM;
    ESC_read (ESCREG_SM2, (void *) &ESCvar.SM[2], sizeof (ESCvar.SM[2]));
    SM = (_ESCsm2 *) & ESCvar.SM[2];
-   
+
    /* Check SM settings */
    if ((etohs (SM->PSA) != ESC_SM2_sma) ||
        (SM->Command != ESC_SM2_smc))
@@ -904,7 +904,7 @@ void ESC_stopinput (void)
  */
 uint8_t ESC_startoutput (uint8_t state)
 {
-	
+
    /* If outputs > 0 , enable SM2 */
    if (ESCvar.ESC_SM2_sml > 0)
    {

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -3,10 +3,13 @@
  * LICENSE file in the project root for full license information
  */
 #include <string.h>
+#include <assert.h>
 #include <cc.h>
 #include "esc.h"
 #include "esc_coe.h"
 #include "esc_foe.h"
+
+static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
 
 /** \file
  * \brief

--- a/soes/include/sys/gcc/cc.h
+++ b/soes/include/sys/gcc/cc.h
@@ -19,7 +19,7 @@ extern "C"
 #ifdef __linux__
    #include <endian.h>
 #else
-   #include <machine/endian.h>   
+   #include <machine/endian.h>
 #endif
 
 #ifndef MIN
@@ -41,7 +41,7 @@ extern "C"
 #else
 #define CC_ASSERT(exp) assert (exp)
 #endif
-#define CC_STATIC_ASSERT(exp) _Static_assert (exp, "")
+#define CC_STATIC_ASSERT(exp, msg) _Static_assert (exp, msg)
 
 #define CC_DEPRECATED   __attribute__((deprecated))
 


### PR DESCRIPTION
Check maximum allowed length of service data for incoming mailbox.
Subsequent mailbox services expect a valid length information to access several positions within the mailbox message buffer.

Validate minimum required configured mailbox size.