### PR TITLE
fix: Mailbox out cnt value

### DIFF
--- a/soes/esc.c
+++ b/soes/esc.c
@@ -431,6 +431,7 @@ void ESC_stopmbx (void)
    ESCvar.xoe = 0;
    ESCvar.mbxfree = 1;
    ESCvar.toggle = 0;
+   ESCvar.mbxcnt = 0;
    ESCvar.mbxincnt = 0;
    ESCvar.segmented = 0;
    ESCvar.frags = 0;

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -3,13 +3,12 @@
  * LICENSE file in the project root for full license information
  */
 #include <string.h>
-#include <assert.h>
 #include <cc.h>
 #include "esc.h"
 #include "esc_coe.h"
 #include "esc_foe.h"
 
-static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
+CC_STATIC_ASSERT((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
 
 /** \file
  * \brief

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -19,6 +19,20 @@ static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox
  * State machine and mailbox support.
  */
 
+/** Update and set cnt value for a desired mailbox out buffer.
+ *
+ * @param[in] n   = Index of mailbox buffer.
+ */
+static void setmbxoutcnt (uint8_t const n)
+{
+   ESCvar.mbxcnt = (ESCvar.mbxcnt + 1U) & 0x07U;
+   if (ESCvar.mbxcnt == 0U)
+   {
+      ESCvar.mbxcnt = 1U;
+   }
+   ((_MBXh*)&MBX[n * ESC_MBXSIZE])->mbxcnt = ESCvar.mbxcnt;
+}
+
 /** Write AL Status Code to the ESC.
  *
  * @param[in] errornumber   = Write an by EtherCAT specified Error number register 0x134 AL Status Code
@@ -489,7 +503,7 @@ void ESC_ackmbxread (void)
 
 /** Allocate and prepare a mailbox buffer. Take the first Idle buffer from the End.
  * Set Mailbox control state to be used for outbox and fill the mailbox buffer with
- * address master and mailbox next CNT value between 1-7.
+ * address master.
  *
  * @return The index of Mailbox buffer prepared for outbox. IF no buffer is available return 0.
  */
@@ -505,16 +519,10 @@ uint8_t ESC_claimbuffer (void)
    {
       MBXcontrol[n].state = MBXstate_outclaim;
       MBh = (_MBXh *)&MBX[n * ESC_MBXSIZE];
-      ESCvar.mbxcnt++;
-      ESCvar.mbxcnt = (ESCvar.mbxcnt & 0x07);
-      if (ESCvar.mbxcnt == 0)
-      {
-         ESCvar.mbxcnt = 1;
-      }
       MBh->address = htoes (0x0000);      // destination is master
       MBh->channel = 0;
       MBh->priority = 0;
-      MBh->mbxcnt = ESCvar.mbxcnt & 0xFU;
+      MBh->reserved = 0;
       ESCvar.txcue++;
    }
    return n;
@@ -533,6 +541,7 @@ uint8_t ESC_outreqbuffer (void)
    }
    return n;
 }
+
 /** Allocate and prepare a mailbox buffer for sending an error message. Take the first Idle
  * buffer from the end. Set Mailbox control state to be used for outbox and fill the mailbox
  * buffer with error information.
@@ -642,6 +651,7 @@ uint8_t ESC_mbxprocess (void)
       /* outmbx empty and outreq mbx available */
       if (mbxhandle)
       {
+         setmbxoutcnt (mbxhandle);
          ESC_writembx (mbxhandle);
          /* Refresh SM status */
          ESC_SMstatus (1);

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -658,7 +658,7 @@ uint8_t ESC_mbxprocess (void)
    {
       ESC_readmbx ();
       ESCvar.SM[0].MBXstat = 0;
-      if (etohs (MBh->length) == 0)
+      if ((etohs (MBh->length) == 0) || (etohs (MBh->length) > (ESC_MBX0_sml - ESC_MBXHSIZE)))
       {
          MBX_error (MBXERR_INVALIDHEADER);
          /* drop mailbox */
@@ -712,7 +712,7 @@ uint8_t ESC_checkSM23 (uint8_t state)
    _ESCsm2 *SM;
    ESC_read (ESCREG_SM2, (void *) &ESCvar.SM[2], sizeof (ESCvar.SM[2]));
    SM = (_ESCsm2 *) & ESCvar.SM[2];
-   
+
    /* Check SM settings */
    if ((etohs (SM->PSA) != ESC_SM2_sma) ||
        (SM->Command != ESC_SM2_smc))
@@ -904,7 +904,7 @@ void ESC_stopinput (void)
  */
 uint8_t ESC_startoutput (uint8_t state)
 {
-	
+
    /* If outputs > 0 , enable SM2 */
    if (ESCvar.ESC_SM2_sml > 0)
    {

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -3,10 +3,13 @@
  * LICENSE file in the project root for full license information
  */
 #include <string.h>
+#include <assert.h>
 #include <cc.h>
 #include "esc.h"
 #include "esc_coe.h"
 #include "esc_foe.h"
+
+static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
 
 /** \file
  * \brief
@@ -658,7 +661,7 @@ uint8_t ESC_mbxprocess (void)
    {
       ESC_readmbx ();
       ESCvar.SM[0].MBXstat = 0;
-      if (etohs (MBh->length) == 0)
+      if ((etohs (MBh->length) == 0) || (etohs (MBh->length) > (ESC_MBX0_sml - ESC_MBXHSIZE)))
       {
          MBX_error (MBXERR_INVALIDHEADER);
          /* drop mailbox */
@@ -712,7 +715,7 @@ uint8_t ESC_checkSM23 (uint8_t state)
    _ESCsm2 *SM;
    ESC_read (ESCREG_SM2, (void *) &ESCvar.SM[2], sizeof (ESCvar.SM[2]));
    SM = (_ESCsm2 *) & ESCvar.SM[2];
-   
+
    /* Check SM settings */
    if ((etohs (SM->PSA) != ESC_SM2_sma) ||
        (SM->Command != ESC_SM2_smc))
@@ -904,7 +907,7 @@ void ESC_stopinput (void)
  */
 uint8_t ESC_startoutput (uint8_t state)
 {
-	
+
    /* If outputs > 0 , enable SM2 */
    if (ESCvar.ESC_SM2_sml > 0)
    {

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -3,10 +3,13 @@
  * LICENSE file in the project root for full license information
  */
 #include <string.h>
+#include <assert.h>
 #include <cc.h>
 #include "esc.h"
 #include "esc_coe.h"
 #include "esc_foe.h"
+
+static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
 
 /** \file
  * \brief

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -523,14 +523,16 @@ typedef struct CC_PACKED
    uint8_t priority:2;
 
    uint8_t mbxtype:4;
-   uint8_t mbxcnt:4;
+   uint8_t mbxcnt:3;
+   uint8_t reserved:1;
 #endif
 
 #if defined(EC_BIG_ENDIAN)
    uint8_t priority:2;
    uint8_t channel:6;
 
-   uint8_t mbxcnt:4;
+   uint8_t reserved:1;
+   uint8_t mbxcnt:3;
    uint8_t mbxtype:4;
 #endif
 } _MBXh;

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -12,6 +12,7 @@
 #define __esc_coe__
 
 #include <cc.h>
+#include "options.h"
 
 
 typedef struct
@@ -133,6 +134,11 @@ extern uint32_t ESC_upload_pre_objecthandler (uint16_t index,
       size_t *size,
       uint16_t flags);
 extern uint32_t ESC_upload_post_objecthandler (uint16_t index, uint8_t subindex, uint16_t flags);
+
+#if USE_CONST_OBJECTLIST
 extern const _objectlist SDOobjects[];
+#else
+extern _objectlist SDOobjects[];
+#endif
 
 #endif

--- a/soes/include/sys/gcc/cc.h
+++ b/soes/include/sys/gcc/cc.h
@@ -19,7 +19,7 @@ extern "C"
 #ifdef __linux__
    #include <endian.h>
 #else
-   #include <machine/endian.h>   
+   #include <machine/endian.h>
 #endif
 
 #ifndef MIN
@@ -41,7 +41,7 @@ extern "C"
 #else
 #define CC_ASSERT(exp) assert (exp)
 #endif
-#define CC_STATIC_ASSERT(exp) _Static_assert (exp, "")
+#define CC_STATIC_ASSERT(exp, msg) _Static_assert (exp, msg)
 
 #define CC_DEPRECATED   __attribute__((deprecated))
 

--- a/soes/options.h
+++ b/soes/options.h
@@ -9,6 +9,11 @@
 /* User-defined options, Options defined here will override default values */
 #include "ecat_options.h"
 
+/* SDOobjects to be provided as const */
+#ifndef USE_CONST_OBJECTLIST
+#define USE_CONST_OBJECTLIST  1
+#endif
+
 /* FoE support */
 #ifndef USE_FOE
 #define USE_FOE          1


### PR DESCRIPTION
Set cnt value just before a mailbox message is sent.
Since mailbox messages may sent in different order than the messages were claimed, the correct cnt value can even be determined at the time, when the message is sent out.

Adjust bitfield for cnt value within mailbox header structure.

Reset mailbox out cnt value when mailbox is stopped.

( Also included: Pull Request #194 )