### PR TITLE
fix: SDO service

### DIFF
--- a/soes/esc.c
+++ b/soes/esc.c
@@ -3,13 +3,12 @@
  * LICENSE file in the project root for full license information
  */
 #include <string.h>
-#include <assert.h>
 #include <cc.h>
 #include "esc.h"
 #include "esc_coe.h"
 #include "esc_foe.h"
 
-static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
+CC_STATIC_ASSERT((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
 
 /** \file
  * \brief

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -19,6 +19,20 @@ static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox
  * State machine and mailbox support.
  */
 
+/** Update and set cnt value for a desired mailbox out buffer.
+ *
+ * @param[in] n   = Index of mailbox buffer.
+ */
+static void setmbxoutcnt (uint8_t const n)
+{
+   ESCvar.mbxcnt = (ESCvar.mbxcnt + 1U) & 0x07U;
+   if (ESCvar.mbxcnt == 0U)
+   {
+      ESCvar.mbxcnt = 1U;
+   }
+   ((_MBXh*)&MBX[n * ESC_MBXSIZE])->mbxcnt = ESCvar.mbxcnt;
+}
+
 /** Write AL Status Code to the ESC.
  *
  * @param[in] errornumber   = Write an by EtherCAT specified Error number register 0x134 AL Status Code
@@ -489,7 +503,7 @@ void ESC_ackmbxread (void)
 
 /** Allocate and prepare a mailbox buffer. Take the first Idle buffer from the End.
  * Set Mailbox control state to be used for outbox and fill the mailbox buffer with
- * address master and mailbox next CNT value between 1-7.
+ * address master.
  *
  * @return The index of Mailbox buffer prepared for outbox. IF no buffer is available return 0.
  */
@@ -505,16 +519,10 @@ uint8_t ESC_claimbuffer (void)
    {
       MBXcontrol[n].state = MBXstate_outclaim;
       MBh = (_MBXh *)&MBX[n * ESC_MBXSIZE];
-      ESCvar.mbxcnt++;
-      ESCvar.mbxcnt = (ESCvar.mbxcnt & 0x07);
-      if (ESCvar.mbxcnt == 0)
-      {
-         ESCvar.mbxcnt = 1;
-      }
       MBh->address = htoes (0x0000);      // destination is master
       MBh->channel = 0;
       MBh->priority = 0;
-      MBh->mbxcnt = ESCvar.mbxcnt & 0xFU;
+      MBh->reserved = 0;
       ESCvar.txcue++;
    }
    return n;
@@ -533,6 +541,7 @@ uint8_t ESC_outreqbuffer (void)
    }
    return n;
 }
+
 /** Allocate and prepare a mailbox buffer for sending an error message. Take the first Idle
  * buffer from the end. Set Mailbox control state to be used for outbox and fill the mailbox
  * buffer with error information.
@@ -642,6 +651,7 @@ uint8_t ESC_mbxprocess (void)
       /* outmbx empty and outreq mbx available */
       if (mbxhandle)
       {
+         setmbxoutcnt (mbxhandle);
          ESC_writembx (mbxhandle);
          /* Refresh SM status */
          ESC_SMstatus (1);

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -3,10 +3,13 @@
  * LICENSE file in the project root for full license information
  */
 #include <string.h>
+#include <assert.h>
 #include <cc.h>
 #include "esc.h"
 #include "esc_coe.h"
 #include "esc_foe.h"
+
+static_assert((MBXSIZE > ESC_MBXHSIZE) && (MBXSIZEBOOT > ESC_MBXHSIZE), "Mailbox size too small.");
 
 /** \file
  * \brief
@@ -658,7 +661,7 @@ uint8_t ESC_mbxprocess (void)
    {
       ESC_readmbx ();
       ESCvar.SM[0].MBXstat = 0;
-      if (etohs (MBh->length) == 0)
+      if ((etohs (MBh->length) == 0) || (etohs (MBh->length) > (ESC_MBX0_sml - ESC_MBXHSIZE)))
       {
          MBX_error (MBXERR_INVALIDHEADER);
          /* drop mailbox */
@@ -712,7 +715,7 @@ uint8_t ESC_checkSM23 (uint8_t state)
    _ESCsm2 *SM;
    ESC_read (ESCREG_SM2, (void *) &ESCvar.SM[2], sizeof (ESCvar.SM[2]));
    SM = (_ESCsm2 *) & ESCvar.SM[2];
-   
+
    /* Check SM settings */
    if ((etohs (SM->PSA) != ESC_SM2_sma) ||
        (SM->Command != ESC_SM2_smc))
@@ -904,7 +907,7 @@ void ESC_stopinput (void)
  */
 uint8_t ESC_startoutput (uint8_t state)
 {
-	
+
    /* If outputs > 0 , enable SM2 */
    if (ESCvar.ESC_SM2_sml > 0)
    {

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -433,6 +433,7 @@ void ESC_stopmbx (void)
    ESCvar.toggle = 0;
    ESCvar.mbxincnt = 0;
    ESCvar.segmented = 0;
+   ESCvar.segmentedToggle = 0;
    ESCvar.frags = 0;
    ESCvar.fragsleft = 0;
    ESCvar.txcue = 0;

--- a/soes/esc.c
+++ b/soes/esc.c
@@ -431,6 +431,7 @@ void ESC_stopmbx (void)
    ESCvar.xoe = 0;
    ESCvar.mbxfree = 1;
    ESCvar.toggle = 0;
+   ESCvar.mbxcnt = 0;
    ESCvar.mbxincnt = 0;
    ESCvar.segmented = 0;
    ESCvar.segmentedToggle = 0;

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -487,6 +487,7 @@ typedef struct
    uint8_t txcue;
    uint8_t mbxfree;
    uint8_t segmented;
+   uint8_t segmentedToggle;
    void *data;
    uint16_t entries;
    uint32_t frags;

--- a/soes/esc.h
+++ b/soes/esc.h
@@ -523,14 +523,16 @@ typedef struct CC_PACKED
    uint8_t priority:2;
 
    uint8_t mbxtype:4;
-   uint8_t mbxcnt:4;
+   uint8_t mbxcnt:3;
+   uint8_t reserved:1;
 #endif
 
 #if defined(EC_BIG_ENDIAN)
    uint8_t priority:2;
    uint8_t channel:6;
 
-   uint8_t mbxcnt:4;
+   uint8_t reserved:1;
+   uint8_t mbxcnt:3;
    uint8_t mbxtype:4;
 #endif
 } _MBXh;

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -484,8 +484,7 @@ static uint32_t complete_access_get_variables(_COEsdo *coesdo, uint16_t *index,
  * @param[in] load_type = Indicates 'DOWNLOAD' or 'UPLOAD' to be performed.
  * @param[in] max_bytes = Maximum number of bytes when to interrupt the iteration.\n
  *                        If 0, iteration is performed till the end of the desired object.
- * @return Number of bits affected to this iteration.\n
- *         Errorcode 'ABORT_CA_NOT_SUPPORTED' if the object has an unsupported datatype.
+ * @return Number of bits affected to this iteration.
  */
 static uint32_t complete_access_subindex_loop(int32_t const nidx,
                                               int16_t nsub,
@@ -652,12 +651,6 @@ static void SDO_upload_complete_access (void)
 
    /* loop through the subindexes to get the total size */
    uint32_t size = complete_access_subindex_loop(nidx, nsub, NULL, UPLOAD, 0);
-   if (size == (size_t)ABORT_CA_NOT_SUPPORTED)
-   {
-      /* 'size' is in this case actually an abort code */
-      set_state_idle (MBXout, index, subindex, size);
-      return;
-   }
 
    /* expedited bits used calculation */
    uint8_t dss = (size > 24) ? 0 : (uint8_t)(4U * (3U - ((size - 1U) >> 3)));
@@ -1000,12 +993,6 @@ static void SDO_download_complete_access (void)
    {
       /* loop through the subindexes to get the total size */
       size = complete_access_subindex_loop(nidx, nsub, NULL, DOWNLOAD, 0);
-      if (size == (size_t)ABORT_CA_NOT_SUPPORTED)
-      {
-         /* 'size' is in this case actually an abort code */
-         set_state_idle (0, index, subindex, size);
-         return;
-      }
       size = BITS2BYTES(size);
    }
 

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -514,7 +514,9 @@ static uint32_t complete_access_subindex_loop(int32_t const nidx,
                          ? 0U
                          : isNumberOfSubindexesChanging
                          ? ((uint8_t*)mbxdata)[0]
-                         : *(uint8_t*)(objd->data);
+                         : (objd->data != NULL)
+                         ? *(uint8_t*)(objd->data)
+                         : (uint8_t)objd->value;
 
    while (nsub <= maxsub)
    {

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -1359,16 +1359,15 @@ static void SDO_getod (void)
          coel->index = htoes (index);
          if (SDOobjects[nidx].objtype == OTYPE_VAR)
          {
-            int32_t nsub = SDO_findsubindex (nidx, 0);
             const _objd *objd = SDOobjects[nidx].objdesc;
-            coel->datatype = htoes ((objd + nsub)->datatype);
+            coel->datatype = htoes ((objd + 0U)->datatype);
             coel->maxsub = SDOobjects[nidx].maxsub;
          }
-         else if (SDOobjects[nidx].objtype == OTYPE_ARRAY)
+         else if (   (SDOobjects[nidx].objtype == OTYPE_ARRAY)
+                  && (SDOobjects[nidx].maxsub >= 1U))
          {
-            int32_t nsub = SDO_findsubindex (nidx, 0);
             const _objd *objd = SDOobjects[nidx].objdesc;
-            coel->datatype = htoes ((objd + nsub)->datatype);
+            coel->datatype = htoes ((objd + 1U)->datatype);
             coel->maxsub = (uint8_t)SDOobjects[nidx].objdesc->value;
          }
          else

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -495,12 +495,6 @@ static uint32_t complete_access_subindex_loop(int32_t const nidx,
 {
    /* Objects with dynamic entries cannot be accessed with Complete Access */
    _objd const * const objd = SDOobjects[nidx].objdesc;
-   if ((objd->datatype == DTYPE_VISIBLE_STRING) ||
-       (objd->datatype == DTYPE_OCTET_STRING)   ||
-       (objd->datatype == DTYPE_UNICODE_STRING))
-   {
-      return ABORT_CA_NOT_SUPPORTED;
-   }
 
    uint32_t size = 0;
 

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -588,7 +588,7 @@ static uint32_t complete_access_subindex_loop(int32_t const nidx,
          /* download of RO objects shall be ignored */
          else if (WRITE_ACCESS(access, state))
          {
-            *(uint8_t*)(objd + nsub)->data = (mbxdata[BITS2BYTES(size)] & (uint8_t)bitmask) >> bitoffset;
+            *(uint8_t*)(objd + nsub)->data = (mbxdata[BITSPOS2BYTESOFFSET(size)] >> bitoffset) & (uint8_t)bitmask;
          }
       }
 

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -661,7 +661,7 @@ static void SDO_upload_complete_access (void)
    size = BITS2BYTES(size);
 
    /* check that upload data fits in the preallocated buffer */
-   if ((size + PREALLOC_FACTOR * COE_HEADERSIZE) > PREALLOC_BUFFER_SIZE)
+   if (size > PREALLOC_BUFFER_SIZE)
    {
       set_state_idle (MBXout, index, subindex, ABORT_CA_NOT_SUPPORTED);
       return;
@@ -888,12 +888,6 @@ static void SDO_download (void)
                if (   ((coesdo->command & COE_EXPEDITED_INDICATOR) == 0U)
                    && (size > (etohs (coesdo->mbxheader.length) - COE_HEADERSIZE)))
                {
-                  /* check that download data fits in the preallocated buffer */
-                  if (size > PREALLOC_BUFFER_SIZE)
-                  {
-                    set_state_idle(0, index, subindex, ABORT_UNSUPPORTED);
-                    return;
-                  }
                   ESCvar.frags = size;
                   size = etohs (coesdo->mbxheader.length) - COE_HEADERSIZE;
                   ESCvar.fragsleft = size;

--- a/soes/esc_coe.c
+++ b/soes/esc_coe.c
@@ -828,7 +828,12 @@ static void SDO_download (void)
                mbxdata = (&(coesdo->size)) + 1;
             }
             actsize = BITS2BYTES((objd + nsub)->bitlength);
-            if (actsize != size)
+            if (actsize < size)
+            {
+               set_state_idle (0, index, subindex, ABORT_TYPEMISMATCH);
+               return;
+            }
+            if (actsize > size)
             {
                /* entries with data types VISIBLE_STRING, OCTET_STRING,
                 * UNICODE_STRING, ARRAY_OF_INT, ARRAY_OF_SINT,

--- a/soes/esc_coe.h
+++ b/soes/esc_coe.h
@@ -12,6 +12,7 @@
 #define __esc_coe__
 
 #include <cc.h>
+#include "options.h"
 
 
 typedef struct
@@ -133,6 +134,11 @@ extern uint32_t ESC_upload_pre_objecthandler (uint16_t index,
       size_t *size,
       uint16_t flags);
 extern uint32_t ESC_upload_post_objecthandler (uint16_t index, uint8_t subindex, uint16_t flags);
+
+#if USE_CONST_OBJECTLIST
 extern const _objectlist SDOobjects[];
+#else
+extern _objectlist SDOobjects[];
+#endif
 
 #endif

--- a/soes/include/sys/gcc/cc.h
+++ b/soes/include/sys/gcc/cc.h
@@ -19,7 +19,7 @@ extern "C"
 #ifdef __linux__
    #include <endian.h>
 #else
-   #include <machine/endian.h>   
+   #include <machine/endian.h>
 #endif
 
 #ifndef MIN
@@ -41,7 +41,7 @@ extern "C"
 #else
 #define CC_ASSERT(exp) assert (exp)
 #endif
-#define CC_STATIC_ASSERT(exp) _Static_assert (exp, "")
+#define CC_STATIC_ASSERT(exp, msg) _Static_assert (exp, msg)
 
 #define CC_DEPRECATED   __attribute__((deprecated))
 

--- a/soes/options.h
+++ b/soes/options.h
@@ -9,6 +9,11 @@
 /* User-defined options, Options defined here will override default values */
 #include "ecat_options.h"
 
+/* SDOobjects to be provided as const */
+#ifndef USE_CONST_OBJECTLIST
+#define USE_CONST_OBJECTLIST  1
+#endif
+
 /* FoE support */
 #ifndef USE_FOE
 #define USE_FOE          1


### PR DESCRIPTION
Abort sdo download request if size exceeds allowed length.
Only accept ca download if size matches.
Fix complete access of bit data types.
Allow ca access for objects with flexible length.
Correct validation of sdo segmented request.
Serve correct datatype for SDO get object description.
Correct size limit for complete access.

(Also included: Pull-Request #194 and #197 )