### PR TITLE
Allow delayed ESM state-change

### DIFF
--- a/soes/esc.h
+++ b/soes/esc.h
@@ -314,7 +314,7 @@ typedef struct esc_cfg
    int watchdog_cnt;
    bool skip_default_initialization;
    void (*set_defaults_hook) (void);
-   void (*pre_state_change_hook) (uint8_t * as, uint8_t * an);
+   void (*pre_state_change_hook) (uint8_t * as, uint8_t * an, bool * ack);
    void (*post_state_change_hook) (uint8_t * as, uint8_t * an);
    void (*application_hook) (void);
    void (*safeoutput_override) (void);
@@ -439,7 +439,7 @@ typedef struct
    sm_cfg_t  mbboot[2];
    bool skip_default_initialization;
    void (*set_defaults_hook) (void);
-   void (*pre_state_change_hook) (uint8_t * as, uint8_t * an);
+   void (*pre_state_change_hook) (uint8_t * as, uint8_t * an, bool * ack);
    void (*post_state_change_hook) (uint8_t * as, uint8_t * an);
    void (*application_hook) (void);
    void (*safeoutput_override) (void);
@@ -476,6 +476,7 @@ typedef struct
    uint16_t synccounterlimit;
    uint16_t ALstatus;
    uint16_t ALcontrol;
+   bool ALcontrol_pending;
    uint16_t ALerror;
    uint16_t DLstatus;
    uint16_t address;


### PR DESCRIPTION
Keep pending AL-Control-Event flag in ESCvar so a state-change request does not need to be serviced immediately. Also add an acknowledge-parameter to the pre_state_change()-callback which may be negated by the routine in order to postpone a state-change to the next run of the slave handler.

When AL-control request is asserted by master, the according AL-event flag is set by the ESC. The according AL-Event flag is cleared on reading the AL-Control register right at the top of ESC_state(); so the routine only ran once per AL-Control-Request. With the ESCvar.ALcontrol_pending flag, a not yet finished state-change allows running the state-change logic again until the state-change gets acknowledged by the pre_state_change() callback.

This approach allows SOES to service other requests (e.g. mailbox) while a state-change is pending.

Why ist this needed?
*A slave that needs some time to become (Pre-)Operational, e.g. one that needs to accelerate a rotating mass before entering PreOp needs to be able to delay a state change without setting the ALerror bit*


